### PR TITLE
[codex] Document package-owned ecosystem seams

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,15 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
+        env:
+          FAMILY_BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade \
-            "design-research-analysis @ git+https://github.com/cmudrc/design-research-analysis.git@main" \
-            "design-research-agents @ git+https://github.com/cmudrc/design-research-agents.git@main" \
-            "design-research-problems @ git+https://github.com/cmudrc/design-research-problems.git@main" \
-            "design-research-experiments @ git+https://github.com/cmudrc/design-research-experiments.git@main"
+            "design-research-analysis @ git+https://github.com/cmudrc/design-research-analysis.git@${FAMILY_BRANCH}" \
+            "design-research-agents @ git+https://github.com/cmudrc/design-research-agents.git@${FAMILY_BRANCH}" \
+            "design-research-problems @ git+https://github.com/cmudrc/design-research-problems.git@${FAMILY_BRANCH}" \
+            "design-research-experiments @ git+https://github.com/cmudrc/design-research-experiments.git@${FAMILY_BRANCH}"
           pip install -e ".[dev]"
 
       - name: Run local CI gate
@@ -60,13 +62,15 @@ jobs:
           cache: pip
 
       - name: Install dependencies
+        env:
+          FAMILY_BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade \
-            "design-research-analysis @ git+https://github.com/cmudrc/design-research-analysis.git@main" \
-            "design-research-agents @ git+https://github.com/cmudrc/design-research-agents.git@main" \
-            "design-research-problems @ git+https://github.com/cmudrc/design-research-problems.git@main" \
-            "design-research-experiments @ git+https://github.com/cmudrc/design-research-experiments.git@main"
+            "design-research-analysis @ git+https://github.com/cmudrc/design-research-analysis.git@${FAMILY_BRANCH}" \
+            "design-research-agents @ git+https://github.com/cmudrc/design-research-agents.git@${FAMILY_BRANCH}" \
+            "design-research-problems @ git+https://github.com/cmudrc/design-research-problems.git@${FAMILY_BRANCH}" \
+            "design-research-experiments @ git+https://github.com/cmudrc/design-research-experiments.git@${FAMILY_BRANCH}"
           pip install -e ".[dev]"
 
       - name: Generate coverage artifacts

--- a/README.md
+++ b/README.md
@@ -47,13 +47,14 @@ make examples-test
 
 `make run-example` is the live canonical walkthrough. It uses a managed
 `llama.cpp` client, a workflow-backed strategy comparison, canonical exports,
-and downstream analysis helpers. The live workflow path now uses the sibling
-public seams directly: a prompt-built `design_research.agents.Workflow`,
-`design_research.agents.PromptWorkflowAgent`,
-`design_research.agents.SeededRandomBaselineAgent`,
-`design_research.experiments.resolve_problem(...)`, and
-`design_research.experiments.run_study(..., agent_bindings=...)`, plus
-`design_research.analysis.integration`. Install
+and downstream analysis helpers. The tested cross-library path is now
+package-owned seam first:
+`design_research.problems.integration`,
+`design_research.agents.integration`,
+`design_research.experiments`, and
+`design_research.analysis.integration`.
+`design_research.experiments` itself stays the orchestration surface rather than
+adding a symmetry-only `integration` module. Install
 `llama-cpp-python[server]` first. If you want the client to fetch its default
 GGUF model automatically, also install `huggingface-hub`; otherwise set
 `LLAMA_CPP_MODEL` to a specific local GGUF file.

--- a/docs/compatibility.rst
+++ b/docs/compatibility.rst
@@ -30,15 +30,20 @@ Tested Package Combination
 These versions match the exact sibling pins in ``pyproject.toml`` and represent
 the tested umbrella combination for the current docs baseline.
 
-The bundled examples and smoke tests intentionally target the April 2026 family
-interop seams directly: ``design_research_experiments.resolve_problem(...)``,
-public ``design_research_agents.SeededRandomBaselineAgent`` and
-``design_research_agents.PromptWorkflowAgent`` participants, a prompt-built
-``design_research_agents.Workflow``, and
-``design_research_analysis.integration``. The shipped example scripts expect
-installed sibling packages; adjacent sibling worktrees are preferred only by
-the family-sync and subprocess example tests so the umbrella package can verify
-current sibling ``main`` APIs during contributor workflows.
+The bundled examples and smoke tests now target the package-owned cross-library
+path explicitly:
+
+- ``design_research_problems.integration``
+- ``design_research_agents.integration``
+- ``design_research_experiments``
+- ``design_research_analysis.integration``
+
+``design_research_experiments`` remains the orchestration surface, so there is
+intentionally no separate ``design_research_experiments.integration`` module.
+The shipped example scripts expect installed sibling packages; adjacent sibling
+worktrees are preferred only by the family-sync and subprocess example tests so
+the umbrella package can verify current sibling ``main`` APIs during
+contributor workflows.
 
 Start Here Vs Go Direct
 -----------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -78,6 +78,10 @@ studying human and AI design behavior.
 Together these libraries support end-to-end design research pipelines, from
 study design through execution and interpretation.
 
+The tested cross-library path uses owner-owned seams in ``problems``,
+``agents``, and ``analysis``, with ``design-research-experiments`` itself
+serving as the orchestration layer.
+
 .. container:: drc-home-ecosystem
 
    .. image:: _static/ecosystem-platform.svg

--- a/src/design_research/agents.py
+++ b/src/design_research/agents.py
@@ -2,17 +2,33 @@
 
 from __future__ import annotations
 
+from importlib import import_module
 from typing import Final
 
 from ._lazy import module_dir, public_module_exports, resolve_lazy_export
 
 _EXPORTS: Final[dict[str, str]] = public_module_exports("design_research_agents")
+_OPTIONAL_MODULE_EXPORTS: Final[dict[str, str]] = {
+    "integration": "design_research_agents.integration",
+}
 
 __all__ = list(_EXPORTS.keys())
+for export_name in _OPTIONAL_MODULE_EXPORTS:
+    if export_name not in __all__:
+        __all__.append(export_name)
 
 
 def __getattr__(name: str) -> object:
     """Resolve a deferred export from ``design_research_agents``."""
+    module_path = _OPTIONAL_MODULE_EXPORTS.get(name)
+    if module_path is not None:
+        try:
+            module = import_module(module_path)
+        except ModuleNotFoundError as exc:
+            raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
+        globals()[name] = module
+        return module
+
     return resolve_lazy_export(__name__, _EXPORTS, name)
 
 

--- a/src/design_research/problems.py
+++ b/src/design_research/problems.py
@@ -2,17 +2,33 @@
 
 from __future__ import annotations
 
+from importlib import import_module
 from typing import Final
 
 from ._lazy import module_dir, public_module_exports, resolve_lazy_export
 
 _EXPORTS: Final[dict[str, str]] = public_module_exports("design_research_problems")
+_OPTIONAL_MODULE_EXPORTS: Final[dict[str, str]] = {
+    "integration": "design_research_problems.integration",
+}
 
 __all__ = list(_EXPORTS.keys())
+for export_name in _OPTIONAL_MODULE_EXPORTS:
+    if export_name not in __all__:
+        __all__.append(export_name)
 
 
 def __getattr__(name: str) -> object:
     """Resolve a deferred export from ``design_research_problems``."""
+    module_path = _OPTIONAL_MODULE_EXPORTS.get(name)
+    if module_path is not None:
+        try:
+            module = import_module(module_path)
+        except ModuleNotFoundError as exc:
+            raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
+        globals()[name] = module
+        return module
+
     return resolve_lazy_export(__name__, _EXPORTS, name)
 
 

--- a/tests/test_family_smoke.py
+++ b/tests/test_family_smoke.py
@@ -76,6 +76,7 @@ def test_april_family_wrapper_exports_track_local_siblings() -> None:
     assert dr.analysis.__all__ == sibling_analysis.__all__
     assert dr.problems.__all__ == sibling_problems.__all__
     assert dr.agents.Workflow is sibling_agents.Workflow
+    assert dr.agents.integration is sibling_agents.integration
     assert dr.experiments.build_strategy_comparison_study is (
         sibling_experiments.build_strategy_comparison_study
     )
@@ -86,6 +87,7 @@ def test_april_family_wrapper_exports_track_local_siblings() -> None:
     assert dr.analysis.visualization is sibling_analysis.visualization
     assert dr.analysis.__version__ == sibling_analysis.__version__
     assert dr.problems.list_problems is sibling_problems.list_problems
+    assert dr.problems.integration is sibling_problems.integration
     assert dr.problems.__version__ == sibling_problems.__version__
 
 

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -41,7 +41,9 @@ def test_wrapper_dir_exposes_lazy_exports() -> None:
     assert "permutation_test" in dir(analysis)
     assert "run_study" in dir(experiments)
     assert "list_problems" in dir(problems)
+    assert "integration" in dir(problems)
     assert "Citation" in dir(problems)
+    assert "integration" in dir(agents)
 
 
 def test_version_module_exposes_single_source_of_truth() -> None:

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -52,6 +52,8 @@ def _install_dependency_stubs() -> dict[str, ModuleType]:
     problems.get_problem_as = _fn("get_problem_as")
     problems.list_problems = _fn("list_problems")
     problems.get_ideation_catalog = _fn("get_ideation_catalog")
+    problems_integration = ModuleType("design_research_problems.integration")
+    problems.integration = problems_integration
     problems.__all__ = [
         "__version__",
         "Problem",
@@ -82,6 +84,7 @@ def _install_dependency_stubs() -> dict[str, ModuleType]:
         "get_problem_as",
         "list_problems",
         "get_ideation_catalog",
+        "integration",
     ]
 
     agents = ModuleType("design_research_agents")
@@ -137,6 +140,8 @@ def _install_dependency_stubs() -> dict[str, ModuleType]:
         "RAGPattern",
     ]:
         setattr(agents, symbol, type(symbol, (), {}))
+    agents_integration = ModuleType("design_research_agents.integration")
+    agents.integration = agents_integration
     agents.__all__ = [
         "__version__",
         "DirectLLMCall",
@@ -187,6 +192,7 @@ def _install_dependency_stubs() -> dict[str, ModuleType]:
         "SGLangServerLLMClient",
         "ModelSelector",
         "Tracer",
+        "integration",
     ]
 
     experiments = ModuleType("design_research_experiments")
@@ -449,7 +455,9 @@ def _install_dependency_stubs() -> dict[str, ModuleType]:
 
     stubs = {
         "design_research_problems": problems,
+        "design_research_problems.integration": problems_integration,
         "design_research_agents": agents,
+        "design_research_agents.integration": agents_integration,
         "design_research_experiments": experiments,
         "design_research_analysis": analysis,
         "design_research_analysis.dataset": analysis_dataset,
@@ -485,7 +493,9 @@ def test_wrapper_re_exports_are_reachable_via_stubs(monkeypatch: Any) -> None:
 
     assert problems.get_problem()[0] == "get_problem"
     assert problems.list_problems()[0] == "list_problems"
+    assert problems.integration.__name__ == "design_research_problems.integration"
     assert agents.MultiStepAgent.__name__ == "MultiStepAgent"
+    assert agents.integration.__name__ == "design_research_agents.integration"
     assert agents.CompiledExecution.__name__ == "CompiledExecution"
     assert agents.LlamaCppServerLLMClient.__name__ == "LlamaCppServerLLMClient"
     assert agents.ModelStep.__name__ == "ModelStep"


### PR DESCRIPTION
## What changed
- update umbrella docs and compatibility guidance to point at the package-owned cross-library path
- expose and test the new `problems.integration` and `agents.integration` wrapper seams through the umbrella package
- clarify that `design_research_experiments` itself remains the orchestration surface

## Why
The umbrella package should mirror the owner-owned seams without inventing new cross-library API layers.

## Impact
The start-here path is clearer: `design_research.problems.integration`, `design_research.agents.integration`, `design_research.experiments`, and `design_research.analysis.integration`.

## Validation
- `PYTHONPATH=src uv run --python 3.12 pytest -q tests/test_family_smoke.py tests/test_internals.py tests/test_wrappers.py`
