### PR TITLE
Add canonical artifact flow example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade \
-            "design-research-analysis @ git+https://github.com/cmudrc/design-research-analysis.git@main" \
-            "design-research-agents @ git+https://github.com/cmudrc/design-research-agents.git@main" \
-            "design-research-problems @ git+https://github.com/cmudrc/design-research-problems.git@main" \
-            "design-research-experiments @ git+https://github.com/cmudrc/design-research-experiments.git@main"
+            "design-research-analysis @ git+https://github.com/cmudrc/design-research-analysis.git@mellon-metrics-april-2026" \
+            "design-research-agents @ git+https://github.com/cmudrc/design-research-agents.git@lovelace-lift-april-2026" \
+            "design-research-problems @ git+https://github.com/cmudrc/design-research-problems.git@monarch-maze-april-2026" \
+            "design-research-experiments @ git+https://github.com/cmudrc/design-research-experiments.git@mariner-matrix-april-2026"
           pip install -e ".[dev]"
 
       - name: Run local CI gate
@@ -63,10 +63,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade \
-            "design-research-analysis @ git+https://github.com/cmudrc/design-research-analysis.git@main" \
-            "design-research-agents @ git+https://github.com/cmudrc/design-research-agents.git@main" \
-            "design-research-problems @ git+https://github.com/cmudrc/design-research-problems.git@main" \
-            "design-research-experiments @ git+https://github.com/cmudrc/design-research-experiments.git@main"
+            "design-research-analysis @ git+https://github.com/cmudrc/design-research-analysis.git@mellon-metrics-april-2026" \
+            "design-research-agents @ git+https://github.com/cmudrc/design-research-agents.git@lovelace-lift-april-2026" \
+            "design-research-problems @ git+https://github.com/cmudrc/design-research-problems.git@monarch-maze-april-2026" \
+            "design-research-experiments @ git+https://github.com/cmudrc/design-research-experiments.git@mariner-matrix-april-2026"
           pip install -e ".[dev]"
 
       - name: Generate coverage artifacts

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -27,10 +27,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade \
-            "design-research-analysis @ git+https://github.com/cmudrc/design-research-analysis.git@main" \
-            "design-research-agents @ git+https://github.com/cmudrc/design-research-agents.git@main" \
-            "design-research-problems @ git+https://github.com/cmudrc/design-research-problems.git@main" \
-            "design-research-experiments @ git+https://github.com/cmudrc/design-research-experiments.git@main"
+            "design-research-analysis @ git+https://github.com/cmudrc/design-research-analysis.git@mellon-metrics-april-2026" \
+            "design-research-agents @ git+https://github.com/cmudrc/design-research-agents.git@lovelace-lift-april-2026" \
+            "design-research-problems @ git+https://github.com/cmudrc/design-research-problems.git@monarch-maze-april-2026" \
+            "design-research-experiments @ git+https://github.com/cmudrc/design-research-experiments.git@mariner-matrix-april-2026"
           pip install -e ".[dev]"
 
       - name: Run deterministic examples

--- a/README.md
+++ b/README.md
@@ -37,18 +37,22 @@ python -m venv .venv
 source .venv/bin/activate
 make dev
 make test
+python examples/canonical_artifact_flow.py
 python -m pip install "llama-cpp-python[server]" huggingface-hub
 make run-example
 make examples-test
 ```
 
-`make run-example` is the live canonical walkthrough. It uses a managed
+`examples/canonical_artifact_flow.py` is the deterministic compatibility smoke
+path: a packaged problem, public baseline agent, experiment artifacts, and
+analysis validation through the umbrella namespace.
+
+`make run-example` is the live walkthrough. It uses a managed
 `llama.cpp` client, a workflow-backed strategy comparison, canonical exports,
 and downstream analysis helpers. The live workflow path now uses the sibling
 public seams directly: a prompt-built `design_research.agents.Workflow`,
 `design_research.agents.PromptWorkflowAgent`,
 `design_research.agents.SeededRandomBaselineAgent`,
-`design_research.experiments.resolve_problem(...)`, and
 `design_research.experiments.run_study(..., agent_bindings=...)`, plus
 `design_research.analysis.integration`. Install
 `llama-cpp-python[server]` first. If you want the client to fetch its default
@@ -56,7 +60,7 @@ GGUF model automatically, also install `huggingface-hub`; otherwise set
 `LLAMA_CPP_MODEL` to a specific local GGUF file.
 
 `make examples-test` stays deterministic and offline-first by default. It runs
-the two non-live recipe-first examples and skips the live walkthrough unless
+the three non-live recipe-first examples and skips the live walkthrough unless
 `RUN_LIVE_EXAMPLE=1`.
 
 Install from PyPI:
@@ -93,7 +97,8 @@ Choose your entry point based on how much of the ecosystem you need:
 - Start with `design-research` when you want one stable namespace and one set of docs across problems, agents, experiments, and analysis.
 - Install a sibling package directly when you only need one layer or want package-specific internals; direct sibling use is fully supported.
 - See [Compatibility and Start Here](https://cmudrc.github.io/design-research/compatibility.html) for the tested package combination and install guidance.
-- See [Prompt-Framing Study Walkthrough](https://cmudrc.github.io/design-research/prompt_framing_study.html) for the canonical live composed workflow, and the bundled deterministic examples for the smaller recipe-first entry points.
+- See [Canonical Artifact Flow](https://cmudrc.github.io/design-research/canonical_artifact_flow.html) for the deterministic all-layer handoff.
+- See [Prompt-Framing Study Walkthrough](https://cmudrc.github.io/design-research/prompt_framing_study.html) for the live composed workflow.
 
 ## Ecosystem Integration
 

--- a/docs/canonical_artifact_flow.rst
+++ b/docs/canonical_artifact_flow.rst
@@ -1,0 +1,28 @@
+Canonical Artifact Flow
+=======================
+
+This is the smallest deterministic example that still crosses the full
+ecosystem boundary:
+
+- ``design_research.problems`` loads a packaged benchmark.
+- ``design_research.agents`` supplies the public seeded baseline agent.
+- ``design_research.experiments`` builds and runs the study, then exports
+  canonical artifacts.
+- ``design_research.analysis`` validates and reads those artifacts.
+
+It is the compatibility smoke path for the examples workflow: no live model, no
+network dependency, and no umbrella-owned orchestration logic.
+
+Run it with:
+
+.. code-block:: bash
+
+   python examples/canonical_artifact_flow.py
+
+Code
+----
+
+.. literalinclude:: ../examples/canonical_artifact_flow.py
+   :language: python
+   :linenos:
+   :caption: ``examples/canonical_artifact_flow.py``

--- a/docs/compatibility.rst
+++ b/docs/compatibility.rst
@@ -31,14 +31,15 @@ These versions match the exact sibling pins in ``pyproject.toml`` and represent
 the tested umbrella combination for the current docs baseline.
 
 The bundled examples and smoke tests intentionally target the April 2026 family
-interop seams directly: ``design_research_experiments.resolve_problem(...)``,
-public ``design_research_agents.SeededRandomBaselineAgent`` and
-``design_research_agents.PromptWorkflowAgent`` participants, a prompt-built
-``design_research_agents.Workflow``, and
-``design_research_analysis.integration``. The shipped example scripts expect
-installed sibling packages; adjacent sibling worktrees are preferred only by
-the family-sync and subprocess example tests so the umbrella package can verify
-current sibling ``main`` APIs during contributor workflows.
+interop seams directly. :doc:`canonical_artifact_flow` is the no-network smoke
+path: it resolves a packaged problem, runs the public seeded baseline agent,
+exports canonical experiment artifacts, and validates them with
+``design_research_analysis.integration``. The live walkthrough adds
+``PromptWorkflowAgent`` and a prompt-built ``Workflow`` on top of that same
+artifact contract. The shipped example scripts expect installed sibling
+packages; adjacent sibling worktrees are preferred only by the family-sync and
+subprocess example tests so the umbrella package can verify current sibling
+``main`` APIs during contributor workflows.
 
 Start Here Vs Go Direct
 -----------------------
@@ -79,6 +80,6 @@ date.
 Next Step
 ---------
 
-If you want to see the umbrella package drive a real composed workflow, use the
-deterministic bundled examples for the smallest recipe-first entry points and
-continue to :doc:`prompt_framing_study` for the live canonical walkthrough.
+If you want to see the umbrella package drive a real composed workflow, start
+with :doc:`canonical_artifact_flow` and continue to :doc:`prompt_framing_study`
+for the live walkthrough.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,8 +38,8 @@ together and when to drop into the more specialized repos directly.
    .. note::
 
       **Start with** :doc:`compatibility` to choose between the umbrella package
-      and direct sibling installs, then follow :doc:`prompt_framing_study` for
-      the canonical real-agent workflow example built from the umbrella namespace.
+      and direct sibling installs, then run :doc:`canonical_artifact_flow` for
+      the deterministic all-layer handoff.
 
 Guides
 ------
@@ -48,6 +48,7 @@ Use these pages to understand the umbrella package, the shared namespace, and
 the recommended path through the ecosystem.
 
 - :doc:`compatibility`
+- :doc:`canonical_artifact_flow`
 - :doc:`prompt_framing_study`
 - :doc:`quickstart`
 - :doc:`installation`
@@ -90,6 +91,7 @@ Start Here
 ----------
 
 - :doc:`compatibility`
+- :doc:`canonical_artifact_flow`
 - :doc:`prompt_framing_study`
 - :doc:`quickstart`
 - :doc:`installation`
@@ -104,6 +106,7 @@ Start Here
    :hidden:
 
    compatibility
+   canonical_artifact_flow
    prompt_framing_study
    quickstart
    installation

--- a/docs/prompt_framing_study.rst
+++ b/docs/prompt_framing_study.rst
@@ -19,9 +19,6 @@ What This Covers
 ----------------
 
 - resolves a real packaged problem through ``design_research.problems``
-- resolves that problem through the sibling-owned
-  ``design_research.experiments.resolve_problem`` interop API so packaged
-  evaluations normalize cleanly into experiment rows
 - builds the study from
   ``design_research.experiments.build_strategy_comparison_study`` with a
   recipe-first benchmark bundle containing a random baseline, a neutral

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -14,7 +14,13 @@ Local development setup:
    make dev
    make test
 
-Run the bundled example:
+Run the deterministic all-layer example:
+
+.. code-block:: bash
+
+   python examples/canonical_artifact_flow.py
+
+Run the live bundled example:
 
 .. code-block:: bash
 
@@ -22,7 +28,7 @@ Run the bundled example:
    make run-example
    make examples-test
 
-``make run-example`` executes the canonical umbrella-level walkthrough that
+``make run-example`` executes the live umbrella-level walkthrough that
 uses a real packaged problem, a live model-backed workflow agent, canonical
 experiment artifacts, and exported event-table validation.
 
@@ -32,7 +38,7 @@ download path to work, also install ``huggingface-hub``; otherwise set
 ``LLAMA_CPP_MODEL`` to a specific local GGUF file.
 
 ``make examples-test`` stays deterministic and offline-first by default. It
-exercises the two smaller recipe-first examples and skips the live
+exercises the three smaller recipe-first examples and skips the live
 walkthrough unless ``RUN_LIVE_EXAMPLE=1``.
 
 Build the docs:

--- a/docs/typical_workflow.rst
+++ b/docs/typical_workflow.rst
@@ -8,7 +8,6 @@ Typical Workflow
    - ``design_research.experiments`` for study definitions and orchestration.
    - ``design_research.analysis`` for downstream analysis and reporting.
 3. Build end-to-end studies by composing these layers without duplicating logic.
-   Start with the deterministic recipe-first examples for the smallest study
-   entry points, then see :doc:`prompt_framing_study` for the canonical live
-   walkthrough.
+   Start with :doc:`canonical_artifact_flow` for the smallest all-layer handoff,
+   then see :doc:`prompt_framing_study` for the live walkthrough.
 4. Keep package-specific details in component repositories.

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,7 +34,7 @@ make examples-test
 `examples/prompt_framing_study.py`. Install `llama-cpp-python[server]` first.
 If you want the default model download path, also install `huggingface-hub`;
 otherwise set `LLAMA_CPP_MODEL` to a specific local GGUF file. The live study
-defaults to eight replicates per condition; set `PROMPT_STUDY_REPLICATES` to
+defaults to 50 replicates per condition; set `PROMPT_STUDY_REPLICATES` to
 run a larger sample.
 
 `make examples-test` stays deterministic and offline-first by default. It runs

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,6 +3,9 @@
 The examples in this repository are intentionally small, recipe-first, and
 future-branch oriented.
 
+- `canonical_artifact_flow.py` is the smallest deterministic all-layer handoff:
+  one packaged problem, one public baseline agent, one experiment run path,
+  canonical artifacts, and analysis validation.
 - `student_laptop_design_study.py` is the smallest application-first decision
   study. It runs the packaged student laptop benchmark, prints the chosen
   laptop configuration, and reports the evaluator's observed market metrics.
@@ -28,7 +31,7 @@ defaults to eight replicates per condition; set `PROMPT_STUDY_REPLICATES` to
 run a larger sample.
 
 `make examples-test` stays deterministic and offline-first by default. It runs
-the two non-live examples and skips the live walkthrough unless
+the three non-live examples and skips the live walkthrough unless
 `RUN_LIVE_EXAMPLE=1`.
 
 The examples prefer adjacent sibling worktrees during local development so

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,13 @@ future-branch oriented.
 - `pump_and_battery_design_portfolio.py` is the packaged engineering portfolio
   example. It runs real pump and battery optimization benchmarks, reports the
   observed objective and feasibility results, and previews a second recipe.
+- `long_agent_markov_comparison.py` runs long scripted agent traces under two
+  treatments and compares their exported process traces as Markov-chain
+  transition matrices.
+- `model_size_sweep_regression.py` sweeps model sizes within one model class and
+  fits a regression directly from canonical experiment artifacts.
+- `partial_factorial_ideation_regression.py` samples a larger model-by-task
+  ideation design and fits a linear model without user-facing table plumbing.
 - `prompt_framing_study.py` is the canonical live walkthrough. It keeps the
   managed `llama.cpp` runtime, workflow-backed strategy arms, pairwise
   condition comparisons, and markdown reporting.
@@ -31,7 +38,7 @@ defaults to eight replicates per condition; set `PROMPT_STUDY_REPLICATES` to
 run a larger sample.
 
 `make examples-test` stays deterministic and offline-first by default. It runs
-the three non-live examples and skips the live walkthrough unless
+the six non-live examples and skips the live walkthrough unless
 `RUN_LIVE_EXAMPLE=1`.
 
 The examples prefer adjacent sibling worktrees during local development so

--- a/examples/canonical_artifact_flow.py
+++ b/examples/canonical_artifact_flow.py
@@ -16,7 +16,12 @@ PRIMARY_METRIC = "primary_outcome"
 
 def main() -> None:
     """Run one packaged problem through the public umbrella stack."""
+    # Start with a packaged benchmark from design-research-problems. The umbrella
+    # import keeps the example focused on the workflow instead of package wiring.
     problem = dr.problems.get_problem(PROBLEM_ID)
+
+    # Build the smallest useful study: one problem, one public agent, and two
+    # deterministic replicates so the analysis layer has real rows to consume.
     study = dr.experiments.build_strategy_comparison_study(
         dr.experiments.StrategyComparisonConfig(
             study_id=STUDY_ID,
@@ -34,6 +39,8 @@ def main() -> None:
         )
     )
 
+    # Materialize the abstract recipe into condition rows, then execute those
+    # rows through design-research-experiments.
     conditions = dr.experiments.build_design(study)
     results = dr.experiments.run_study(
         study,
@@ -41,6 +48,9 @@ def main() -> None:
         checkpoint=False,
         show_progress=False,
     )
+
+    # Export canonical analysis tables. This is the main ecosystem handoff:
+    # experiments writes artifacts that analysis can read directly.
     artifacts = dr.experiments.export_analysis_tables(
         study,
         conditions=conditions,
@@ -49,6 +59,8 @@ def main() -> None:
         validate_with_analysis_package=True,
     )
 
+    # Load and validate the exported event table through design-research-analysis
+    # so the example demonstrates the artifact contract, not private objects.
     loaded = dr.analysis.integration.load_experiment_artifacts(artifacts["events.csv"])
     event_report = dr.analysis.integration.validate_experiment_events(artifacts["events.csv"])
     metric_rows = dr.analysis.build_condition_metric_table(
@@ -58,6 +70,9 @@ def main() -> None:
         conditions=loaded["conditions.csv"],
         evaluations=loaded["evaluations.csv"],
     )
+
+    # Reporting helpers live with experiments because they know the study shape,
+    # while analysis owns the statistical and tabular transforms.
     summary_path = dr.experiments.write_markdown_report(
         study.output_dir,
         "canonical_artifact_flow_summary.md",
@@ -67,6 +82,8 @@ def main() -> None:
     values = [float(row["value"]) for row in metric_rows]
     successes = sum(result.status.value == "success" for result in results)
 
+    # Keep terminal output compact: enough to confirm the packages worked
+    # together and point readers at the generated artifacts.
     print("Canonical artifact flow:", study.study_id)
     print("Package path: problems -> agents -> experiments -> analysis")
     print("Problem:", problem.metadata.title)

--- a/examples/canonical_artifact_flow.py
+++ b/examples/canonical_artifact_flow.py
@@ -1,0 +1,82 @@
+"""Smallest deterministic problems-agents-experiments-analysis handoff."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from statistics import mean
+
+import design_research as dr
+
+PROBLEM_ID = "decision_laptop_design_profit_maximization"
+AGENT_ID = "SeededRandomBaselineAgent"
+STUDY_ID = "canonical_artifact_flow"
+OUTPUT_DIR = Path("artifacts") / "examples" / STUDY_ID
+PRIMARY_METRIC = "primary_outcome"
+
+
+def main() -> None:
+    """Run one packaged problem through the public umbrella stack."""
+    problem = dr.problems.get_problem(PROBLEM_ID)
+    study = dr.experiments.build_strategy_comparison_study(
+        dr.experiments.StrategyComparisonConfig(
+            study_id=STUDY_ID,
+            title="Canonical Artifact Flow",
+            description="Run the minimal composed ecosystem path and validate its artifacts.",
+            bundle=dr.experiments.BenchmarkBundle(
+                bundle_id="canonical-artifact-flow",
+                name="Canonical Artifact Flow",
+                description="One packaged benchmark and one public baseline agent.",
+                problem_ids=(PROBLEM_ID,),
+                agent_specs=(AGENT_ID,),
+            ),
+            run_budget=dr.experiments.RunBudget(replicates=2, parallelism=1, max_runs=2),
+            output_dir=OUTPUT_DIR,
+        )
+    )
+
+    conditions = dr.experiments.build_design(study)
+    results = dr.experiments.run_study(
+        study,
+        conditions=conditions,
+        checkpoint=False,
+        show_progress=False,
+    )
+    artifacts = dr.experiments.export_analysis_tables(
+        study,
+        conditions=conditions,
+        run_results=results,
+        output_dir=study.output_dir / "analysis",
+        validate_with_analysis_package=True,
+    )
+
+    loaded = dr.analysis.integration.load_experiment_artifacts(artifacts["events.csv"])
+    event_report = dr.analysis.integration.validate_experiment_events(artifacts["events.csv"])
+    metric_rows = dr.analysis.build_condition_metric_table(
+        loaded["runs.csv"],
+        metric=PRIMARY_METRIC,
+        condition_column="agent_id",
+        conditions=loaded["conditions.csv"],
+        evaluations=loaded["evaluations.csv"],
+    )
+    summary_path = dr.experiments.write_markdown_report(
+        study.output_dir,
+        "canonical_artifact_flow_summary.md",
+        dr.experiments.render_markdown_summary(study, results),
+    )
+
+    values = [float(row["value"]) for row in metric_rows]
+    successes = sum(result.status.value == "success" for result in results)
+
+    print("Canonical artifact flow:", study.study_id)
+    print("Package path: problems -> agents -> experiments -> analysis")
+    print("Problem:", problem.metadata.title)
+    print("Agent:", AGENT_ID)
+    print("Runs:", len(results), f"({successes} success)")
+    print(f"Mean {PRIMARY_METRIC}:", f"{mean(values):.4f}")
+    print("Event rows valid:", event_report.is_valid, f"(rows={event_report.n_rows})")
+    print("Summary report:", summary_path.name)
+    print("Artifacts directory:", artifacts["events.csv"].parent)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/canonical_artifact_flow.py
+++ b/examples/canonical_artifact_flow.py
@@ -59,16 +59,13 @@ def main() -> None:
         validate_with_analysis_package=True,
     )
 
-    # Load and validate the exported event table through design-research-analysis
-    # so the example demonstrates the artifact contract, not private objects.
-    loaded = dr.analysis.integration.load_experiment_artifacts(artifacts["events.csv"])
-    event_report = dr.analysis.integration.validate_experiment_events(artifacts["events.csv"])
-    metric_rows = dr.analysis.build_condition_metric_table(
-        loaded["runs.csv"],
+    # Validate the exported event table and build the metric summary directly
+    # from artifacts, without asking the user to load the CSV tables.
+    event_report = dr.analysis.validate_experiment_events(artifacts["events.csv"])
+    metric_rows = dr.analysis.build_condition_metric_table_from_artifacts(
+        artifacts["events.csv"],
         metric=PRIMARY_METRIC,
         condition_column="agent_id",
-        conditions=loaded["conditions.csv"],
-        evaluations=loaded["evaluations.csv"],
     )
 
     # Reporting helpers live with experiments because they know the study shape,

--- a/examples/long_agent_markov_comparison.py
+++ b/examples/long_agent_markov_comparison.py
@@ -1,0 +1,172 @@
+"""Compare long agent process traces as condition-specific Markov chains."""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Mapping
+from pathlib import Path
+from statistics import mean
+
+import design_research as dr
+
+STUDY_ID = "long_agent_markov_comparison"
+OUTPUT_DIR = Path("artifacts") / "examples" / STUDY_ID
+PROBLEM_ID = "ideation_accessible_drinking_fountain"
+BASELINE_AGENT = "baseline_agent"
+PLANNER_AGENT = "planner_agent"
+ACTION_COUNT = 30
+PRIMARY_METRIC = "primary_outcome"
+
+TRANSITIONS = {
+    BASELINE_AGENT: {
+        "inspect": ("sketch", "retrieve", "sketch", "critique"),
+        "retrieve": ("sketch", "inspect", "sketch", "revise"),
+        "sketch": ("sketch", "critique", "revise", "select"),
+        "critique": ("revise", "sketch", "select", "inspect"),
+        "revise": ("sketch", "critique", "select", "sketch"),
+        "select": ("sketch", "critique", "inspect", "select"),
+    },
+    PLANNER_AGENT: {
+        "inspect": ("retrieve", "retrieve", "sketch", "critique"),
+        "retrieve": ("sketch", "critique", "sketch", "revise"),
+        "sketch": ("critique", "revise", "critique", "select"),
+        "critique": ("revise", "retrieve", "revise", "select"),
+        "revise": ("critique", "select", "select", "sketch"),
+        "select": ("inspect", "retrieve", "critique", "select"),
+    },
+}
+
+
+def main() -> None:
+    """Run two agent treatments, then compare their transition matrices."""
+    problem = dr.problems.get_problem(PROBLEM_ID)
+    study = dr.experiments.Study(
+        study_id=STUDY_ID,
+        title="Long Agent Markov Comparison",
+        description=(
+            "Run long synthetic traces with the same action vocabulary and compare "
+            "condition-specific Markov-chain matrices from exported artifacts."
+        ),
+        factors=(
+            dr.experiments.Factor(
+                name="agent_id",
+                description="Agent process treatment.",
+                levels=(
+                    dr.experiments.Level(name=BASELINE_AGENT, value=BASELINE_AGENT),
+                    dr.experiments.Level(name=PLANNER_AGENT, value=PLANNER_AGENT),
+                ),
+            ),
+        ),
+        problem_ids=(PROBLEM_ID,),
+        run_budget=dr.experiments.RunBudget(replicates=10, parallelism=1, max_runs=20),
+        output_dir=OUTPUT_DIR,
+    )
+    conditions = dr.experiments.build_design(study)
+    results = dr.experiments.run_study(
+        study,
+        conditions=conditions,
+        agent_bindings={BASELINE_AGENT: _agent_run, PLANNER_AGENT: _agent_run},
+        checkpoint=False,
+        show_progress=False,
+    )
+    artifacts = dr.experiments.export_analysis_tables(
+        study,
+        conditions=conditions,
+        run_results=results,
+        output_dir=study.output_dir / "analysis",
+        validate_with_analysis_package=True,
+    )
+
+    chains = dr.analysis.fit_markov_chains_from_artifacts(
+        artifacts["events.csv"],
+        condition_column="agent_id",
+        session_column="run_id",
+    )
+    comparison = dr.analysis.compare_markov_chains_from_artifacts(
+        artifacts["events.csv"],
+        condition_column="agent_id",
+        left_condition=PLANNER_AGENT,
+        right_condition=BASELINE_AGENT,
+        session_column="run_id",
+    )
+    metric_rows = dr.analysis.build_condition_metric_table_from_artifacts(
+        artifacts["events.csv"],
+        metric=PRIMARY_METRIC,
+        condition_column="agent_id",
+    )
+    validation = dr.analysis.validate_experiment_events(artifacts["events.csv"])
+
+    means = _means_by_condition(metric_rows)
+    print("Long agent Markov comparison:", study.study_id)
+    print("Problem:", problem.metadata.title)
+    print("Actions per run:", ACTION_COUNT)
+    print("Runs:", len(results))
+    print("Event rows valid:", validation.is_valid, f"(rows={validation.n_rows})")
+    print("States:", len(chains[PLANNER_AGENT].states))
+    print("Mean primary_outcome:")
+    for agent_id in (BASELINE_AGENT, PLANNER_AGENT):
+        print(f"- {agent_id}: {means[agent_id]:.3f}")
+    print("Transition matrix delta:", f"{comparison.estimate:.4f}")
+    if comparison.p_value is not None:
+        print("Transition matrix p-value:", f"{comparison.p_value:.4f}")
+    print("Artifacts directory:", artifacts["events.csv"].parent)
+
+
+def _agent_run(
+    *,
+    condition: dr.experiments.Condition,
+    problem_packet: dr.experiments.ProblemPacket,
+    seed: int,
+) -> dict[str, object]:
+    agent_id = str(condition.factor_assignments["agent_id"])
+    rng = random.Random(seed)
+    action = "inspect"
+    events = []
+    for step in range(1, ACTION_COUNT + 1):
+        action = rng.choice(TRANSITIONS[agent_id][action])
+        events.append(
+            {
+                "event_type": action,
+                "actor_id": "agent",
+                "text": f"{action} step for {problem_packet.problem_id}",
+                "step_id": f"step-{step:02d}",
+                "meta_json": {"step": step},
+            }
+        )
+
+    score = _score_events(events, agent_id=agent_id)
+    return {
+        "output": {"text": f"{agent_id} final concept score {score:.3f}"},
+        "metrics": {
+            PRIMARY_METRIC: score,
+            "input_tokens": 180 + ACTION_COUNT,
+            "output_tokens": 90 + (2 * ACTION_COUNT),
+        },
+        "events": events,
+        "metadata": {
+            "agent_kind": "scripted",
+            "model_name": agent_id,
+            "pattern_name": "long-process-trace",
+        },
+    }
+
+
+def _score_events(events: list[Mapping[str, object]], *, agent_id: str) -> float:
+    actions = [str(event["event_type"]) for event in events]
+    deliberate_moves = (
+        actions.count("retrieve") + actions.count("critique") + actions.count("revise")
+    )
+    selection_bonus = 0.04 * actions[-6:].count("select")
+    treatment_bonus = 0.10 if agent_id == PLANNER_AGENT else 0.0
+    return 0.45 + (0.012 * deliberate_moves) + selection_bonus + treatment_bonus
+
+
+def _means_by_condition(rows: list[dict[str, object]]) -> dict[str, float]:
+    grouped: dict[str, list[float]] = {}
+    for row in rows:
+        grouped.setdefault(str(row["condition"]), []).append(float(row["value"]))
+    return {condition: mean(values) for condition, values in grouped.items()}
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/long_agent_markov_comparison.py
+++ b/examples/long_agent_markov_comparison.py
@@ -39,7 +39,12 @@ TRANSITIONS = {
 
 def main() -> None:
     """Run two agent treatments, then compare their transition matrices."""
+    # The problem package supplies the real design-task context. The agents below
+    # stay scripted so the example can focus on process traces and analysis.
     problem = dr.problems.get_problem(PROBLEM_ID)
+
+    # Both treatments get the same action vocabulary and run budget. Only the
+    # transition tendencies differ, which makes the Markov comparison meaningful.
     study = dr.experiments.Study(
         study_id=STUDY_ID,
         title="Long Agent Markov Comparison",
@@ -61,6 +66,9 @@ def main() -> None:
         run_budget=dr.experiments.RunBudget(replicates=10, parallelism=1, max_runs=20),
         output_dir=OUTPUT_DIR,
     )
+
+    # Build the condition table and bind each agent id to the same callable. The
+    # callable reads the condition to choose the scripted transition policy.
     conditions = dr.experiments.build_design(study)
     results = dr.experiments.run_study(
         study,
@@ -69,6 +77,9 @@ def main() -> None:
         checkpoint=False,
         show_progress=False,
     )
+
+    # Export the run history as canonical artifacts. From this point on, the
+    # analysis code works from files rather than the in-memory run objects.
     artifacts = dr.experiments.export_analysis_tables(
         study,
         conditions=conditions,
@@ -77,6 +88,8 @@ def main() -> None:
         validate_with_analysis_package=True,
     )
 
+    # Fit one Markov chain per treatment from event sequences, then compare the
+    # transition matrices directly from the same event artifact.
     chains = dr.analysis.fit_markov_chains_from_artifacts(
         artifacts["events.csv"],
         condition_column="agent_id",
@@ -89,6 +102,9 @@ def main() -> None:
         right_condition=BASELINE_AGENT,
         session_column="run_id",
     )
+
+    # Outcome metrics use the same artifact-first path, so process analysis and
+    # score summaries come from a single exported contract.
     metric_rows = dr.analysis.build_condition_metric_table_from_artifacts(
         artifacts["events.csv"],
         metric=PRIMARY_METRIC,
@@ -97,6 +113,9 @@ def main() -> None:
     validation = dr.analysis.validate_experiment_events(artifacts["events.csv"])
 
     means = _means_by_condition(metric_rows)
+
+    # The printout is intentionally brief: headline process comparison, outcome
+    # means, and the artifact directory for deeper inspection.
     print("Long agent Markov comparison:", study.study_id)
     print("Problem:", problem.metadata.title)
     print("Actions per run:", ACTION_COUNT)
@@ -123,6 +142,9 @@ def _agent_run(
     rng = random.Random(seed)
     action = "inspect"
     events = []
+
+    # Emit a long sequence of canonical events. Each event type is also a Markov
+    # state, which lets analysis reconstruct transition counts without adapters.
     for step in range(1, ACTION_COUNT + 1):
         action = rng.choice(TRANSITIONS[agent_id][action])
         events.append(
@@ -136,6 +158,9 @@ def _agent_run(
         )
 
     score = _score_events(events, agent_id=agent_id)
+
+    # Return the standard agent result shape expected by experiments: output,
+    # metrics, event log, and metadata.
     return {
         "output": {"text": f"{agent_id} final concept score {score:.3f}"},
         "metrics": {

--- a/examples/long_agent_markov_comparison.py
+++ b/examples/long_agent_markov_comparison.py
@@ -118,6 +118,7 @@ def _agent_run(
     problem_packet: dr.experiments.ProblemPacket,
     seed: int,
 ) -> dict[str, object]:
+    """Generate one deterministic long agent trace for a treatment condition."""
     agent_id = str(condition.factor_assignments["agent_id"])
     rng = random.Random(seed)
     action = "inspect"
@@ -152,6 +153,7 @@ def _agent_run(
 
 
 def _score_events(events: list[Mapping[str, object]], *, agent_id: str) -> float:
+    """Compute a simple outcome from the trace structure and treatment."""
     actions = [str(event["event_type"]) for event in events]
     deliberate_moves = (
         actions.count("retrieve") + actions.count("critique") + actions.count("revise")
@@ -162,6 +164,7 @@ def _score_events(events: list[Mapping[str, object]], *, agent_id: str) -> float
 
 
 def _means_by_condition(rows: list[dict[str, object]]) -> dict[str, float]:
+    """Summarize the artifact-derived condition metric rows."""
     grouped: dict[str, list[float]] = {}
     for row in rows:
         grouped.setdefault(str(row["condition"]), []).append(float(row["value"]))

--- a/examples/long_agent_markov_comparison.py
+++ b/examples/long_agent_markov_comparison.py
@@ -159,22 +159,22 @@ def _agent_run(
 
     score = _score_events(events, agent_id=agent_id)
 
-    # Return the standard agent result shape expected by experiments: output,
-    # metrics, event log, and metadata.
-    return {
-        "output": {"text": f"{agent_id} final concept score {score:.3f}"},
-        "metrics": {
+    # Let experiments build the standard custom-agent payload so readers do not
+    # have to memorize the raw return keys.
+    return dr.experiments.agent_result(
+        f"{agent_id} final concept score {score:.3f}",
+        metrics={
             PRIMARY_METRIC: score,
             "input_tokens": 180 + ACTION_COUNT,
             "output_tokens": 90 + (2 * ACTION_COUNT),
         },
-        "events": events,
-        "metadata": {
+        events=events,
+        metadata={
             "agent_kind": "scripted",
             "model_name": agent_id,
             "pattern_name": "long-process-trace",
         },
-    }
+    )
 
 
 def _score_events(events: list[Mapping[str, object]], *, agent_id: str) -> float:

--- a/examples/model_size_sweep_regression.py
+++ b/examples/model_size_sweep_regression.py
@@ -1,0 +1,123 @@
+"""Sweep model sizes within one model class and regress outcomes."""
+
+from __future__ import annotations
+
+import math
+import random
+from pathlib import Path
+
+import design_research as dr
+
+STUDY_ID = "model_size_sweep_regression"
+OUTPUT_DIR = Path("artifacts") / "examples" / STUDY_ID
+PROBLEM_ID = "ideation_bicycle_safety_lock"
+AGENT_ID = "scripted_model_family_agent"
+PRIMARY_METRIC = "primary_outcome"
+MODEL_SIZES_B = (1.5, 3.0, 7.0, 14.0)
+
+
+def main() -> None:
+    """Run a deterministic model-size sweep and fit an artifact-first regression."""
+    problem = dr.problems.get_problem(PROBLEM_ID)
+    study = dr.experiments.Study(
+        study_id=STUDY_ID,
+        title="Model Size Sweep Regression",
+        description="Compare one model class across size tiers using canonical artifacts.",
+        factors=(
+            dr.experiments.Factor(
+                name="model_size_b",
+                description="Parameter count in billions for one model class.",
+                dtype="float",
+                levels=tuple(
+                    dr.experiments.Level(name=f"{size:g}b", value=size) for size in MODEL_SIZES_B
+                ),
+            ),
+        ),
+        problem_ids=(PROBLEM_ID,),
+        agent_specs=(AGENT_ID,),
+        run_budget=dr.experiments.RunBudget(replicates=5, parallelism=1, max_runs=20),
+        output_dir=OUTPUT_DIR,
+    )
+    conditions = dr.experiments.build_design(study)
+    results = dr.experiments.run_study(
+        study,
+        conditions=conditions,
+        agent_bindings={AGENT_ID: _sweep_agent},
+        checkpoint=False,
+        show_progress=False,
+    )
+    artifacts = dr.experiments.export_analysis_tables(
+        study,
+        conditions=conditions,
+        run_results=results,
+        output_dir=study.output_dir / "analysis",
+        validate_with_analysis_package=True,
+    )
+
+    regression = dr.analysis.fit_regression_from_artifacts(
+        artifacts["events.csv"],
+        outcome=PRIMARY_METRIC,
+        predictors=("model_size_b",),
+    )
+    run_rows = dr.analysis.build_run_metric_table_from_artifacts(
+        artifacts["events.csv"],
+        metrics=PRIMARY_METRIC,
+        condition_columns=("model_size_b",),
+    )
+    validation = dr.analysis.validate_experiment_events(artifacts["events.csv"])
+
+    print("Model size sweep regression:", study.study_id)
+    print("Problem:", problem.metadata.title)
+    print("Model class:", "scripted-open-class")
+    print("Runs:", len(results))
+    print("Event rows valid:", validation.is_valid, f"(rows={validation.n_rows})")
+    print("Regression samples:", regression.n_samples)
+    print("Coefficient model_size_b:", f"{regression.coefficients['model_size_b']:.4f}")
+    print("R2:", f"{regression.r2:.3f}")
+    print("Observed size tiers:", ", ".join(_observed_tiers(run_rows)))
+    print("Artifacts directory:", artifacts["events.csv"].parent)
+
+
+def _sweep_agent(
+    *,
+    condition: dr.experiments.Condition,
+    problem_packet: dr.experiments.ProblemPacket,
+    seed: int,
+) -> dict[str, object]:
+    size_b = float(condition.factor_assignments["model_size_b"])
+    rng = random.Random(seed)
+    noise = rng.uniform(-0.015, 0.015)
+    score = 0.52 + (0.08 * math.log2(size_b + 1.0)) + noise
+    events = [
+        {
+            "event_type": "inspect",
+            "text": problem_packet.brief[:80],
+            "meta_json": {"size_b": size_b},
+        },
+        {"event_type": "ideate", "text": f"draft concepts with {size_b:g}b model"},
+        {"event_type": "select", "text": "select strongest safety-lock concept"},
+    ]
+    return {
+        "output": {"text": f"{size_b:g}b concept set"},
+        "metrics": {
+            PRIMARY_METRIC: score,
+            "input_tokens": 220 + int(size_b * 8),
+            "output_tokens": 90 + int(size_b * 5),
+            "cost_usd": round(size_b * 0.0004, 5),
+        },
+        "events": events,
+        "metadata": {
+            "agent_kind": "scripted",
+            "model_name": f"scripted-open-class-{size_b:g}b",
+            "pattern_name": "model-size-sweep",
+        },
+    }
+
+
+def _observed_tiers(rows: list[dict[str, object]]) -> list[str]:
+    tiers = sorted({float(row["model_size_b"]) for row in rows})
+    return [f"{tier:g}b" for tier in tiers]
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/model_size_sweep_regression.py
+++ b/examples/model_size_sweep_regression.py
@@ -123,23 +123,23 @@ def _sweep_agent(
         {"event_type": "select", "text": "select strongest safety-lock concept"},
     ]
 
-    # Experiments records this standard result shape and analysis later recovers
-    # the metrics and condition labels from exported artifacts.
-    return {
-        "output": {"text": f"{size_b:g}b concept set"},
-        "metrics": {
+    # Let experiments build the standard custom-agent payload. Analysis later
+    # recovers these metrics and condition labels from exported artifacts.
+    return dr.experiments.agent_result(
+        f"{size_b:g}b concept set",
+        metrics={
             PRIMARY_METRIC: score,
             "input_tokens": 220 + int(size_b * 8),
             "output_tokens": 90 + int(size_b * 5),
             "cost_usd": round(size_b * 0.0004, 5),
         },
-        "events": events,
-        "metadata": {
+        events=events,
+        metadata={
             "agent_kind": "scripted",
             "model_name": f"scripted-open-class-{size_b:g}b",
             "pattern_name": "model-size-sweep",
         },
-    }
+    )
 
 
 def _observed_tiers(rows: list[dict[str, object]]) -> list[str]:

--- a/examples/model_size_sweep_regression.py
+++ b/examples/model_size_sweep_regression.py
@@ -18,7 +18,12 @@ MODEL_SIZES_B = (1.5, 3.0, 7.0, 14.0)
 
 def main() -> None:
     """Run a deterministic model-size sweep and fit an artifact-first regression."""
+    # Use one packaged ideation task so model size is the factor being swept,
+    # rather than mixing model effects with task effects.
     problem = dr.problems.get_problem(PROBLEM_ID)
+
+    # The study factor is numeric because the downstream regression should treat
+    # model size as a continuous predictor.
     study = dr.experiments.Study(
         study_id=STUDY_ID,
         title="Model Size Sweep Regression",
@@ -38,6 +43,9 @@ def main() -> None:
         run_budget=dr.experiments.RunBudget(replicates=5, parallelism=1, max_runs=20),
         output_dir=OUTPUT_DIR,
     )
+
+    # The custom binding keeps the run deterministic while still exercising the
+    # same experiments contract used by live model-backed agents.
     conditions = dr.experiments.build_design(study)
     results = dr.experiments.run_study(
         study,
@@ -46,6 +54,9 @@ def main() -> None:
         checkpoint=False,
         show_progress=False,
     )
+
+    # Export first, then analyze. That mirrors the standard workflow where
+    # analysis consumes saved study artifacts rather than private Python objects.
     artifacts = dr.experiments.export_analysis_tables(
         study,
         conditions=conditions,
@@ -54,11 +65,16 @@ def main() -> None:
         validate_with_analysis_package=True,
     )
 
+    # Fit the regression directly from the event artifact. The helper reconstructs
+    # run metrics and condition columns from the canonical tables.
     regression = dr.analysis.fit_regression_from_artifacts(
         artifacts["events.csv"],
         outcome=PRIMARY_METRIC,
         predictors=("model_size_b",),
     )
+
+    # Build a run-level metric table for a simple sanity check of the observed
+    # size tiers that actually reached the artifact layer.
     run_rows = dr.analysis.build_run_metric_table_from_artifacts(
         artifacts["events.csv"],
         metrics=PRIMARY_METRIC,
@@ -66,6 +82,8 @@ def main() -> None:
     )
     validation = dr.analysis.validate_experiment_events(artifacts["events.csv"])
 
+    # Report the regression headline and the generated artifact location, not
+    # every row, so the example stays script-like.
     print("Model size sweep regression:", study.study_id)
     print("Problem:", problem.metadata.title)
     print("Model class:", "scripted-open-class")
@@ -87,8 +105,14 @@ def _sweep_agent(
     """Generate one deterministic ideation result for a model-size condition."""
     size_b = float(condition.factor_assignments["model_size_b"])
     rng = random.Random(seed)
+
+    # Create a monotonic but noisy score so the regression has an interpretable
+    # effect to recover without relying on networked model calls.
     noise = rng.uniform(-0.015, 0.015)
     score = 0.52 + (0.08 * math.log2(size_b + 1.0)) + noise
+
+    # These events are intentionally ordinary design-process moves. They make the
+    # artifact look like a real run while keeping the example deterministic.
     events = [
         {
             "event_type": "inspect",
@@ -98,6 +122,9 @@ def _sweep_agent(
         {"event_type": "ideate", "text": f"draft concepts with {size_b:g}b model"},
         {"event_type": "select", "text": "select strongest safety-lock concept"},
     ]
+
+    # Experiments records this standard result shape and analysis later recovers
+    # the metrics and condition labels from exported artifacts.
     return {
         "output": {"text": f"{size_b:g}b concept set"},
         "metrics": {

--- a/examples/model_size_sweep_regression.py
+++ b/examples/model_size_sweep_regression.py
@@ -84,6 +84,7 @@ def _sweep_agent(
     problem_packet: dr.experiments.ProblemPacket,
     seed: int,
 ) -> dict[str, object]:
+    """Generate one deterministic ideation result for a model-size condition."""
     size_b = float(condition.factor_assignments["model_size_b"])
     rng = random.Random(seed)
     noise = rng.uniform(-0.015, 0.015)
@@ -115,6 +116,7 @@ def _sweep_agent(
 
 
 def _observed_tiers(rows: list[dict[str, object]]) -> list[str]:
+    """Return the sorted model-size tiers observed in artifact-derived rows."""
     tiers = sorted({float(row["model_size_b"]) for row in rows})
     return [f"{tier:g}b" for tier in tiers]
 

--- a/examples/partial_factorial_ideation_regression.py
+++ b/examples/partial_factorial_ideation_regression.py
@@ -183,23 +183,23 @@ def _ideation_agent(
         {"event_type": "select", "text": "select final concept"},
     ]
 
-    # Keep the result payload canonical: final output, metrics, events, and
-    # model metadata. That is enough for experiments and analysis to compose.
-    return {
-        "output": {"text": f"{model_name} concept for {problem_packet.problem_id}"},
-        "metrics": {
+    # Let experiments build the standard custom-agent payload so this example
+    # stays focused on the DOE, not return-shape plumbing.
+    return dr.experiments.agent_result(
+        f"{model_name} concept for {problem_packet.problem_id}",
+        metrics={
             PRIMARY_METRIC: score,
             "input_tokens": 260 + int(size_b * 6),
             "output_tokens": 120 + int(size_b * 3),
             "cost_usd": round(size_b * 0.0005, 5),
         },
-        "events": events,
-        "metadata": {
+        events=events,
+        metadata={
             "agent_kind": "scripted",
             "model_name": model_name,
             "pattern_name": "partial-factorial-ideation",
         },
-    }
+    )
 
 
 def _task_terms(coefficients: dict[str, float]) -> str:

--- a/examples/partial_factorial_ideation_regression.py
+++ b/examples/partial_factorial_ideation_regression.py
@@ -81,6 +81,7 @@ def main() -> None:
 
 
 def _study() -> dr.experiments.Study:
+    """Build the ideation study definition for the partial factorial design."""
     return dr.experiments.Study(
         study_id=STUDY_ID,
         title="Partial Factorial Ideation Regression",
@@ -112,6 +113,7 @@ def _study() -> dr.experiments.Study:
 
 
 def _partial_factorial_conditions() -> list[dr.experiments.Condition]:
+    """Materialize the explicit partial factorial condition matrix."""
     conditions = []
     for index, (model_key, task_key) in enumerate(PARTIAL_ROWS, start=1):
         model_name, model_size_b, model_family = MODEL_LEVELS[model_key]
@@ -139,6 +141,7 @@ def _ideation_agent(
     problem_packet: dr.experiments.ProblemPacket,
     seed: int,
 ) -> dict[str, object]:
+    """Generate one deterministic ideation run for a model-task condition."""
     size_b = float(condition.factor_assignments["model_size_b"])
     model_name = str(condition.factor_assignments["model_name"])
     task_family = str(condition.factor_assignments["task_family"])
@@ -174,6 +177,7 @@ def _ideation_agent(
 
 
 def _task_terms(coefficients: dict[str, float]) -> str:
+    """Format the categorical task-family coefficient names."""
     terms = sorted(name for name in coefficients if name.startswith("task_family["))
     return ", ".join(terms)
 

--- a/examples/partial_factorial_ideation_regression.py
+++ b/examples/partial_factorial_ideation_regression.py
@@ -1,0 +1,182 @@
+"""Run a partial factorial ideation study and fit a linear model."""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+
+import design_research as dr
+
+STUDY_ID = "partial_factorial_ideation_regression"
+OUTPUT_DIR = Path("artifacts") / "examples" / STUDY_ID
+AGENT_ID = "scripted_partial_factorial_ideator"
+PRIMARY_METRIC = "primary_outcome"
+
+MODEL_LEVELS = {
+    "mini": ("open-class-mini", 1.5, "open_class"),
+    "base": ("open-class-base", 7.0, "open_class"),
+    "large": ("open-class-large", 14.0, "open_class"),
+    "reasoner": ("open-class-reasoner", 32.0, "open_class"),
+}
+TASK_LEVELS = {
+    "access": ("ideation_accessible_drinking_fountain", "accessibility", 0.07),
+    "mobility": ("ideation_bicycle_safety_lock", "mobility", 0.02),
+    "workspace": ("ideation_office_sit_stand_table", "furniture", 0.04),
+    "energy": ("ideation_solar_powered_cooking_device", "energy", -0.01),
+    "medical": ("ideation_hospital_blood_pressure_measurement", "medical", 0.00),
+    "agriculture": ("ideation_peanut_shelling", "agriculture", -0.03),
+}
+PARTIAL_ROWS = (
+    ("mini", "access"),
+    ("mini", "energy"),
+    ("mini", "medical"),
+    ("base", "mobility"),
+    ("base", "workspace"),
+    ("base", "agriculture"),
+    ("large", "access"),
+    ("large", "workspace"),
+    ("large", "energy"),
+    ("reasoner", "mobility"),
+    ("reasoner", "medical"),
+    ("reasoner", "agriculture"),
+)
+
+
+def main() -> None:
+    """Run a larger ideation DOE without touching the exported tables directly."""
+    study = _study()
+    conditions = _partial_factorial_conditions()
+    results = dr.experiments.run_study(
+        study,
+        conditions=conditions,
+        agent_bindings={AGENT_ID: _ideation_agent},
+        checkpoint=False,
+        show_progress=False,
+    )
+    artifacts = dr.experiments.export_analysis_tables(
+        study,
+        conditions=conditions,
+        run_results=results,
+        output_dir=study.output_dir / "analysis",
+        validate_with_analysis_package=True,
+    )
+
+    regression = dr.analysis.fit_regression_from_artifacts(
+        artifacts["events.csv"],
+        outcome=PRIMARY_METRIC,
+        predictors=("model_size_b", "task_family"),
+        categorical_predictors=("task_family",),
+    )
+    validation = dr.analysis.validate_experiment_events(artifacts["events.csv"])
+
+    print("Partial factorial ideation regression:", study.study_id)
+    print("Conditions:", len(conditions))
+    print("Runs:", len(results))
+    print("Event rows valid:", validation.is_valid, f"(rows={validation.n_rows})")
+    print("Regression samples:", regression.n_samples)
+    print("Model size coefficient:", f"{regression.coefficients['model_size_b']:.4f}")
+    print("Task family terms:", _task_terms(regression.coefficients))
+    print("R2:", f"{regression.r2:.3f}")
+    print("Artifacts directory:", artifacts["events.csv"].parent)
+
+
+def _study() -> dr.experiments.Study:
+    return dr.experiments.Study(
+        study_id=STUDY_ID,
+        title="Partial Factorial Ideation Regression",
+        description="Sample model-size by design-task combinations and regress ideation quality.",
+        factors=(
+            dr.experiments.Factor(
+                name="model_size_b",
+                description="Parameter count in billions.",
+                dtype="float",
+                levels=tuple(
+                    dr.experiments.Level(name=key, value=size)
+                    for key, (_, size, _) in MODEL_LEVELS.items()
+                ),
+            ),
+            dr.experiments.Factor(
+                name="task_family",
+                description="Ideation task family.",
+                levels=tuple(
+                    dr.experiments.Level(name=key, value=family)
+                    for key, (_, family, _) in TASK_LEVELS.items()
+                ),
+            ),
+        ),
+        agent_specs=(AGENT_ID,),
+        problem_ids=tuple(problem_id for problem_id, _, _ in TASK_LEVELS.values()),
+        run_budget=dr.experiments.RunBudget(replicates=2, parallelism=1, max_runs=24),
+        output_dir=OUTPUT_DIR,
+    )
+
+
+def _partial_factorial_conditions() -> list[dr.experiments.Condition]:
+    conditions = []
+    for index, (model_key, task_key) in enumerate(PARTIAL_ROWS, start=1):
+        model_name, model_size_b, model_family = MODEL_LEVELS[model_key]
+        problem_id, task_family, _ = TASK_LEVELS[task_key]
+        conditions.append(
+            dr.experiments.Condition(
+                condition_id=f"pf-{index:02d}",
+                factor_assignments={
+                    "model_name": model_name,
+                    "model_family": model_family,
+                    "model_size_b": model_size_b,
+                    "task_family": task_family,
+                    "problem_id": problem_id,
+                },
+                block_assignments={},
+                metadata={"model_key": model_key, "task_key": task_key},
+            )
+        )
+    return conditions
+
+
+def _ideation_agent(
+    *,
+    condition: dr.experiments.Condition,
+    problem_packet: dr.experiments.ProblemPacket,
+    seed: int,
+) -> dict[str, object]:
+    size_b = float(condition.factor_assignments["model_size_b"])
+    model_name = str(condition.factor_assignments["model_name"])
+    task_family = str(condition.factor_assignments["task_family"])
+    task_bonus = next(
+        bonus
+        for problem_id, family, bonus in TASK_LEVELS.values()
+        if problem_id == problem_packet.problem_id and family == task_family
+    )
+    rng = random.Random(seed)
+    score = 0.48 + (0.010 * size_b) + task_bonus + rng.uniform(-0.02, 0.02)
+    events = [
+        {"event_type": "inspect", "text": problem_packet.brief[:90]},
+        {"event_type": "analogize", "text": f"look for {task_family} analogies"},
+        {"event_type": "ideate", "text": f"{model_name} drafts alternatives"},
+        {"event_type": "critique", "text": "score novelty and feasibility"},
+        {"event_type": "select", "text": "select final concept"},
+    ]
+    return {
+        "output": {"text": f"{model_name} concept for {problem_packet.problem_id}"},
+        "metrics": {
+            PRIMARY_METRIC: score,
+            "input_tokens": 260 + int(size_b * 6),
+            "output_tokens": 120 + int(size_b * 3),
+            "cost_usd": round(size_b * 0.0005, 5),
+        },
+        "events": events,
+        "metadata": {
+            "agent_kind": "scripted",
+            "model_name": model_name,
+            "pattern_name": "partial-factorial-ideation",
+        },
+    }
+
+
+def _task_terms(coefficients: dict[str, float]) -> str:
+    terms = sorted(name for name in coefficients if name.startswith("task_family["))
+    return ", ".join(terms)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/partial_factorial_ideation_regression.py
+++ b/examples/partial_factorial_ideation_regression.py
@@ -44,8 +44,13 @@ PARTIAL_ROWS = (
 
 def main() -> None:
     """Run a larger ideation DOE without touching the exported tables directly."""
+    # Build the study separately from the condition matrix so the tutorial can
+    # show both pieces of a custom design of experiments.
     study = _study()
     conditions = _partial_factorial_conditions()
+
+    # The scripted agent keeps execution offline and deterministic, but it still
+    # returns the same result shape expected from a live ideation agent.
     results = dr.experiments.run_study(
         study,
         conditions=conditions,
@@ -53,6 +58,9 @@ def main() -> None:
         checkpoint=False,
         show_progress=False,
     )
+
+    # Persist the standard artifacts before analysis. This keeps the example
+    # aligned with a reproducible workflow where tables can be inspected later.
     artifacts = dr.experiments.export_analysis_tables(
         study,
         conditions=conditions,
@@ -61,6 +69,8 @@ def main() -> None:
         validate_with_analysis_package=True,
     )
 
+    # Fit a linear model from artifacts with both a numeric predictor and a
+    # categorical task-family predictor. No user code touches the CSV tables.
     regression = dr.analysis.fit_regression_from_artifacts(
         artifacts["events.csv"],
         outcome=PRIMARY_METRIC,
@@ -69,6 +79,8 @@ def main() -> None:
     )
     validation = dr.analysis.validate_experiment_events(artifacts["events.csv"])
 
+    # Print the regression headline and validation status; the detailed rows stay
+    # in the generated artifacts.
     print("Partial factorial ideation regression:", study.study_id)
     print("Conditions:", len(conditions))
     print("Runs:", len(results))
@@ -82,6 +94,8 @@ def main() -> None:
 
 def _study() -> dr.experiments.Study:
     """Build the ideation study definition for the partial factorial design."""
+    # The factor definitions describe the design space even though this example
+    # samples only a partial matrix below.
     return dr.experiments.Study(
         study_id=STUDY_ID,
         title="Partial Factorial Ideation Regression",
@@ -115,6 +129,9 @@ def _study() -> dr.experiments.Study:
 def _partial_factorial_conditions() -> list[dr.experiments.Condition]:
     """Materialize the explicit partial factorial condition matrix."""
     conditions = []
+
+    # Spell out the partial factorial rows rather than generating a full cross
+    # product. This is the pattern to use when the DOE is intentionally sparse.
     for index, (model_key, task_key) in enumerate(PARTIAL_ROWS, start=1):
         model_name, model_size_b, model_family = MODEL_LEVELS[model_key]
         problem_id, task_family, _ = TASK_LEVELS[task_key]
@@ -145,6 +162,9 @@ def _ideation_agent(
     size_b = float(condition.factor_assignments["model_size_b"])
     model_name = str(condition.factor_assignments["model_name"])
     task_family = str(condition.factor_assignments["task_family"])
+
+    # Each task family has a small deterministic offset so the regression has
+    # categorical terms worth estimating.
     task_bonus = next(
         bonus
         for problem_id, family, bonus in TASK_LEVELS.values()
@@ -152,6 +172,9 @@ def _ideation_agent(
     )
     rng = random.Random(seed)
     score = 0.48 + (0.010 * size_b) + task_bonus + rng.uniform(-0.02, 0.02)
+
+    # The event sequence resembles a lightweight ideation workflow. Analysis can
+    # read these rows later without knowing how the scripted agent was written.
     events = [
         {"event_type": "inspect", "text": problem_packet.brief[:90]},
         {"event_type": "analogize", "text": f"look for {task_family} analogies"},
@@ -159,6 +182,9 @@ def _ideation_agent(
         {"event_type": "critique", "text": "score novelty and feasibility"},
         {"event_type": "select", "text": "select final concept"},
     ]
+
+    # Keep the result payload canonical: final output, metrics, events, and
+    # model metadata. That is enough for experiments and analysis to compose.
     return {
         "output": {"text": f"{model_name} concept for {problem_packet.problem_id}"},
         "metrics": {

--- a/examples/prompt_framing_study.py
+++ b/examples/prompt_framing_study.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import csv
 import importlib.util
-import json
 import os
 from pathlib import Path
 
@@ -63,40 +61,24 @@ def main() -> None:
         agent_bindings = {
             # The neutral condition uses the live model but keeps the instruction
             # framing generic.
-            "neutral_prompt": lambda _condition: dr.agents.PromptWorkflowAgent(
-                workflow=build_json_model_workflow(
-                    llm_client=llm_client,
-                    candidate_schema=candidate_schema,
-                    study_id=STUDY_ID,
-                    problem_id=PROBLEM_ID,
-                    fallback_model_name=str(runtime["model_name"]),
-                    fallback_provider=str(runtime["provider_name"]),
-                ),
-                prompt_builder=lambda problem_packet, _run_spec, _condition: _strategy_prompt(
-                    problem_packet,
-                    instruction=(
-                        "Condition: neutral prompt. Choose the best overall candidate using the "
-                        "packaged demand and feasibility information."
-                    ),
+            "neutral_prompt": _prompt_agent_binding(
+                llm_client=llm_client,
+                candidate_schema=candidate_schema,
+                runtime=runtime,
+                instruction=(
+                    "Condition: neutral prompt. Choose the best overall candidate using the "
+                    "packaged demand and feasibility information."
                 ),
             ),
             # The profit-focused condition swaps only the framing instruction so
             # the study isolates prompt strategy rather than model identity.
-            "profit_focus_prompt": lambda _condition: dr.agents.PromptWorkflowAgent(
-                workflow=build_json_model_workflow(
-                    llm_client=llm_client,
-                    candidate_schema=candidate_schema,
-                    study_id=STUDY_ID,
-                    problem_id=PROBLEM_ID,
-                    fallback_model_name=str(runtime["model_name"]),
-                    fallback_provider=str(runtime["provider_name"]),
-                ),
-                prompt_builder=lambda problem_packet, _run_spec, _condition: _strategy_prompt(
-                    problem_packet,
-                    instruction=(
-                        "Condition: profit-focus prompt. Prioritize choices that maximize "
-                        "market share proxy and expected demand."
-                    ),
+            "profit_focus_prompt": _prompt_agent_binding(
+                llm_client=llm_client,
+                candidate_schema=candidate_schema,
+                runtime=runtime,
+                instruction=(
+                    "Condition: profit-focus prompt. Prioritize choices that maximize "
+                    "market share proxy and expected demand."
                 ),
             ),
         }
@@ -119,38 +101,29 @@ def main() -> None:
         output_dir=OUTPUT_DIR,
     )
 
-    # Load only the CSVs we need for the walkthrough's reporting and statistical
-    # comparison steps.
-    exported_rows = load_analysis_exports(
-        artifact_paths,
-        names=("conditions.csv", "runs.csv", "evaluations.csv"),
-    )
-
     # Confirm that the event-level export is structurally valid before building
     # downstream tables from it.
-    validation_report = validate_exported_events(artifact_paths)
+    validation_report = dr.analysis.validate_experiment_events(artifact_paths["events.csv"])
 
     # Build one condition-by-metric table for the primary outcome we care about
-    # and another for a secondary business-facing metric.
-    primary_metric_rows = dr.analysis.build_condition_metric_table(
-        exported_rows["runs.csv"],
+    # and another for a secondary business-facing metric, without hand-loading CSVs.
+    primary_metric_rows = dr.analysis.build_condition_metric_table_from_artifacts(
+        artifact_paths["events.csv"],
         metric="market_share_proxy",
         condition_column="agent_id",
-        conditions=exported_rows["conditions.csv"],
-        evaluations=exported_rows["evaluations.csv"],
     )
-    demand_metric_rows = dr.analysis.build_condition_metric_table(
-        exported_rows["runs.csv"],
+    demand_metric_rows = dr.analysis.build_condition_metric_table_from_artifacts(
+        artifact_paths["events.csv"],
         metric="expected_demand_units",
         condition_column="agent_id",
-        conditions=exported_rows["conditions.csv"],
-        evaluations=exported_rows["evaluations.csv"],
     )
 
     # Compare the strategy pairs using the analysis package's pairwise
     # permutation test helper.
-    comparison_report = dr.analysis.compare_condition_pairs(
-        primary_metric_rows,
+    comparison_report = dr.analysis.compare_condition_pairs_from_artifacts(
+        artifact_paths["events.csv"],
+        metric="market_share_proxy",
+        condition_column="agent_id",
         condition_pairs=PAIRWISE_COMPARISONS,
         alternative="greater",
         alpha=SIGNIFICANCE_ALPHA,
@@ -261,26 +234,6 @@ def _strategy_prompt(problem_packet: object, *, instruction: str) -> str:
     )
 
 
-def read_csv_rows(path: Path) -> list[dict[str, str]]:
-    """Read one exported CSV table into a list of row dictionaries."""
-    with path.open("r", encoding="utf-8", newline="") as file_obj:
-        return list(csv.DictReader(file_obj))
-
-
-def load_analysis_exports(
-    artifact_paths: dict[str, Path],
-    *,
-    names: tuple[str, ...],
-) -> dict[str, list[dict[str, str]]]:
-    """Load selected exported CSV artifacts into memory."""
-    return {name: read_csv_rows(artifact_paths[name]) for name in names}
-
-
-def validate_exported_events(artifact_paths: dict[str, Path]) -> object:
-    """Validate the exported canonical event table through the analysis layer."""
-    return dr.analysis.integration.validate_experiment_events(artifact_paths["events.csv"])
-
-
 def artifact_names(artifact_paths: dict[str, Path]) -> str:
     """Return exported artifact filenames in stable sorted order."""
     return ", ".join(sorted(path.name for path in artifact_paths.values()))
@@ -367,97 +320,33 @@ def llama_cpp_runtime_config(*, default_replicates: int) -> dict[str, object]:
     }
 
 
-def build_json_model_workflow(
+def _prompt_agent_binding(
     *,
     llm_client: object,
     candidate_schema: dict[str, object],
-    study_id: str,
-    problem_id: str,
-    fallback_model_name: str,
-    fallback_provider: str,
+    runtime: dict[str, object],
+    instruction: str,
 ) -> object:
-    """Build one reusable prompt-mode workflow that returns structured JSON."""
+    """Build one condition-scoped prompt workflow agent binding."""
 
-    def request_builder(context: dict[str, object]) -> object:
-        """Build one structured LLM request from the workflow context."""
-        return dr.agents.LLMRequest(
-            messages=[
-                dr.agents.LLMMessage(
-                    role="system",
-                    content=(
-                        "You are a careful study participant. Return valid JSON only and match "
-                        "the requested schema exactly."
-                    ),
-                ),
-                dr.agents.LLMMessage(role="user", content=str(context["prompt"])),
-            ],
-            temperature=0.0,
-            max_tokens=400,
-            response_schema=candidate_schema,
-            metadata={"study_id": study_id, "problem_id": problem_id},
+    def _binding(_condition: object) -> object:
+        """Return one prompt workflow agent for a concrete experiment condition."""
+        return dr.agents.PromptWorkflowAgent(
+            workflow=dr.agents.build_json_prompt_workflow(
+                llm_client=llm_client,
+                response_schema=candidate_schema,
+                request_metadata={"study_id": STUDY_ID, "problem_id": PROBLEM_ID},
+                default_request_id_prefix=STUDY_ID,
+                fallback_model_name=str(runtime["model_name"]),
+                fallback_provider=str(runtime["provider_name"]),
+            ),
+            prompt_builder=lambda problem_packet, _run_spec, _condition: _strategy_prompt(
+                problem_packet,
+                instruction=instruction,
+            ),
         )
 
-    def response_parser(response: object, _context: dict[str, object]) -> dict[str, object]:
-        """Parse one model response into workflow output, metrics, and events."""
-        model_text = strip_markdown_fences(str(getattr(response, "text", "")).strip())
-        candidate = json.loads(model_text)
-        if not isinstance(candidate, dict):
-            raise RuntimeError("Expected the live workflow to return one JSON object candidate.")
-        provider = str(getattr(response, "provider", "") or fallback_provider)
-        model_name = str(getattr(response, "model", "") or fallback_model_name)
-        return {
-            "final_output": candidate,
-            "metrics": usage_metrics(getattr(response, "usage", None)),
-            "events": [
-                {
-                    "event_type": "model_response",
-                    "actor_id": "agent",
-                    "text": model_text,
-                    "meta_json": {"provider": provider, "model_name": model_name},
-                }
-            ],
-        }
-
-    return dr.agents.Workflow(
-        steps=(
-            dr.agents.ModelStep(
-                step_id="select_candidate",
-                llm_client=llm_client,
-                request_builder=request_builder,
-                response_parser=response_parser,
-            ),
-        ),
-        output_schema=candidate_schema,
-        default_request_id_prefix=study_id,
-    )
-
-
-def strip_markdown_fences(text: str) -> str:
-    """Strip one optional fenced-code wrapper from a model response."""
-    if not text.startswith("```"):
-        return text
-    lines = text.splitlines()
-    if lines and lines[0].startswith("```"):
-        lines = lines[1:]
-    if lines and lines[-1].startswith("```"):
-        lines = lines[:-1]
-    return "\n".join(lines).strip()
-
-
-def usage_metrics(usage: object) -> dict[str, object]:
-    """Normalize usage payloads into canonical metric names."""
-    metrics: dict[str, object] = {"cost_usd": 0.0}
-    if isinstance(usage, dict):
-        prompt_tokens = usage.get("prompt_tokens")
-        completion_tokens = usage.get("completion_tokens")
-    else:
-        prompt_tokens = getattr(usage, "prompt_tokens", None)
-        completion_tokens = getattr(usage, "completion_tokens", None)
-    if isinstance(prompt_tokens, int):
-        metrics["input_tokens"] = prompt_tokens
-    if isinstance(completion_tokens, int):
-        metrics["output_tokens"] = completion_tokens
-    return metrics
+    return _binding
 
 
 if __name__ == "__main__":

--- a/examples/prompt_framing_study.py
+++ b/examples/prompt_framing_study.py
@@ -47,10 +47,6 @@ def main() -> None:
     study = _build_study(replicates=int(runtime["replicates"]))
     conditions = dr.experiments.build_design(study)
 
-    # Resolve the packaged problem once so every run pulls from the same
-    # normalized problem packet.
-    problem_registry = {PROBLEM_ID: dr.experiments.resolve_problem(PROBLEM_ID)}
-
     # Start a managed llama.cpp server client for the duration of the study.
     # The context manager handles startup/shutdown around the live run.
     with dr.agents.LlamaCppServerLLMClient(
@@ -110,7 +106,6 @@ def main() -> None:
             study,
             conditions=conditions,
             agent_bindings=agent_bindings,
-            problem_registry=problem_registry,
             checkpoint=False,
             show_progress=False,
         )

--- a/examples/pump_and_battery_design_portfolio.py
+++ b/examples/pump_and_battery_design_portfolio.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from pathlib import Path
 
 import design_research as dr
@@ -80,12 +79,6 @@ def main() -> None:
     results = dr.experiments.run_study(
         primary_study,
         conditions=conditions,
-        # Resolve each packaged problem through the experiments wrapper so the
-        # study sees normalized problem packets with real evaluator behavior.
-        problem_registry={
-            problem_id: dr.experiments.resolve_problem(problem_id)
-            for problem_id in BENCHMARK_PROBLEM_IDS
-        },
         checkpoint=False,
         show_progress=False,
     )
@@ -100,7 +93,9 @@ def main() -> None:
 
     # Check that the event export is internally consistent before reporting
     # success back to the reader.
-    validation_report = validate_exported_events(artifact_paths)
+    validation_report = dr.analysis.integration.validate_experiment_events(
+        artifact_paths["events.csv"]
+    )
 
     # Write a lightweight markdown summary next to those exported artifacts.
     summary_path = dr.experiments.write_markdown_report(
@@ -137,19 +132,7 @@ def main() -> None:
         )
     print("Event rows valid:", validation_report.is_valid, f"(rows={validation_report.n_rows})")
     print("Summary report:", summary_path.name)
-    print("Artifacts:", artifact_names(artifact_paths))
-
-
-def artifact_names(artifact_paths: Mapping[str, Path]) -> str:
-    """Return exported artifact filenames in stable sorted order."""
-    return ", ".join(sorted(path.name for path in artifact_paths.values()))
-
-
-def validate_exported_events(
-    artifact_paths: Mapping[str, Path],
-) -> object:
-    """Validate the exported canonical event table through the analysis layer."""
-    return dr.analysis.integration.validate_experiment_events(artifact_paths["events.csv"])
+    print("Artifacts directory:", artifact_paths["events.csv"].parent)
 
 
 if __name__ == "__main__":

--- a/examples/pump_and_battery_design_portfolio.py
+++ b/examples/pump_and_battery_design_portfolio.py
@@ -93,9 +93,7 @@ def main() -> None:
 
     # Check that the event export is internally consistent before reporting
     # success back to the reader.
-    validation_report = dr.analysis.integration.validate_experiment_events(
-        artifact_paths["events.csv"]
-    )
+    validation_report = dr.analysis.validate_experiment_events(artifact_paths["events.csv"])
 
     # Write a lightweight markdown summary next to those exported artifacts.
     summary_path = dr.experiments.write_markdown_report(

--- a/examples/student_laptop_design_study.py
+++ b/examples/student_laptop_design_study.py
@@ -79,9 +79,7 @@ def main() -> None:
 
     # Sanity-check that the unified event export is structurally valid before we
     # tell readers to trust the generated artifacts.
-    validation_report = dr.analysis.integration.validate_experiment_events(
-        artifact_paths["events.csv"]
-    )
+    validation_report = dr.analysis.validate_experiment_events(artifact_paths["events.csv"])
 
     # Write one human-readable markdown summary next to the raw CSV artifacts.
     summary_path = dr.experiments.write_markdown_report(

--- a/examples/student_laptop_design_study.py
+++ b/examples/student_laptop_design_study.py
@@ -64,10 +64,6 @@ def main() -> None:
     results = dr.experiments.run_study(
         study,
         conditions=conditions,
-        # Resolve the packaged problem once up front. The April-family path is
-        # that packaged problems flow straight through the umbrella without any
-        # hand-built `ProblemPacket` boilerplate in the example itself.
-        problem_registry={PROBLEM_ID: dr.experiments.resolve_problem(PROBLEM_ID)},
         checkpoint=False,
         show_progress=False,
     )
@@ -83,7 +79,9 @@ def main() -> None:
 
     # Sanity-check that the unified event export is structurally valid before we
     # tell readers to trust the generated artifacts.
-    validation_report = validate_exported_events(artifact_paths)
+    validation_report = dr.analysis.integration.validate_experiment_events(
+        artifact_paths["events.csv"]
+    )
 
     # Write one human-readable markdown summary next to the raw CSV artifacts.
     summary_path = dr.experiments.write_markdown_report(
@@ -132,7 +130,7 @@ def main() -> None:
     for line in chosen_design_lines:
         print(f"- {line}")
     print("Observed results:")
-    print(f"- market_share_proxy={float(evaluator_metrics.get('market_share_proxy', 0.0)):.4f}")
+    print(f"- predicted_share={float(evaluator_metrics.get('predicted_share', 0.0)):.4f}")
     print(
         f"- expected_demand_units={float(evaluator_metrics.get('expected_demand_units', 0.0)):.0f}"
     )
@@ -140,19 +138,7 @@ def main() -> None:
     print(f"- primary_outcome={float(run_result.metrics.get('primary_outcome', 0.0)):.4f}")
     print("Event rows valid:", validation_report.is_valid, f"(rows={validation_report.n_rows})")
     print("Summary report:", summary_path.name)
-    print("Artifacts:", artifact_names(artifact_paths))
-
-
-def artifact_names(artifact_paths: Mapping[str, Path]) -> str:
-    """Return exported artifact filenames in stable sorted order."""
-    return ", ".join(sorted(path.name for path in artifact_paths.values()))
-
-
-def validate_exported_events(
-    artifact_paths: Mapping[str, Path],
-) -> object:
-    """Validate the exported canonical event table through the analysis layer."""
-    return dr.analysis.integration.validate_experiment_events(artifact_paths["events.csv"])
+    print("Artifacts directory:", artifact_paths["events.csv"].parent)
 
 
 if __name__ == "__main__":

--- a/tests/test_example_tooling.py
+++ b/tests/test_example_tooling.py
@@ -30,13 +30,13 @@ def test_generate_examples_metrics_matches_default_execution_policy() -> None:
     inventory = metrics["inventory"]
     public_api = metrics["public_api"]
 
-    assert examples["passed"] == 2
-    assert examples["total"] == 2
-    assert examples["available"] == 3
+    assert examples["passed"] == 3
+    assert examples["total"] == 3
+    assert examples["available"] == 4
     assert examples["skipped"] == 1
     assert examples["run_live_example_enabled"] is False
-    assert inventory["example_file_count"] == 3
-    assert inventory["default_example_count"] == 2
+    assert inventory["example_file_count"] == 4
+    assert inventory["default_example_count"] == 3
     assert inventory["opt_in_example_count"] == 1
     assert inventory["opt_in_examples"] == ["examples/prompt_framing_study.py"]
     assert public_api["covered_exports"] == 4
@@ -51,10 +51,10 @@ def test_generate_examples_metrics_includes_live_walkthrough_when_enabled() -> N
     examples = metrics["examples"]
     inventory = metrics["inventory"]
 
-    assert examples["passed"] == 3
-    assert examples["total"] == 3
-    assert examples["available"] == 3
+    assert examples["passed"] == 4
+    assert examples["total"] == 4
+    assert examples["available"] == 4
     assert examples["skipped"] == 0
     assert examples["run_live_example_enabled"] is True
-    assert inventory["default_example_count"] == 2
+    assert inventory["default_example_count"] == 3
     assert inventory["opt_in_example_count"] == 1

--- a/tests/test_example_tooling.py
+++ b/tests/test_example_tooling.py
@@ -30,13 +30,13 @@ def test_generate_examples_metrics_matches_default_execution_policy() -> None:
     inventory = metrics["inventory"]
     public_api = metrics["public_api"]
 
-    assert examples["passed"] == 3
-    assert examples["total"] == 3
-    assert examples["available"] == 4
+    assert examples["passed"] == 6
+    assert examples["total"] == 6
+    assert examples["available"] == 7
     assert examples["skipped"] == 1
     assert examples["run_live_example_enabled"] is False
-    assert inventory["example_file_count"] == 4
-    assert inventory["default_example_count"] == 3
+    assert inventory["example_file_count"] == 7
+    assert inventory["default_example_count"] == 6
     assert inventory["opt_in_example_count"] == 1
     assert inventory["opt_in_examples"] == ["examples/prompt_framing_study.py"]
     assert public_api["covered_exports"] == 4
@@ -51,10 +51,10 @@ def test_generate_examples_metrics_includes_live_walkthrough_when_enabled() -> N
     examples = metrics["examples"]
     inventory = metrics["inventory"]
 
-    assert examples["passed"] == 4
-    assert examples["total"] == 4
-    assert examples["available"] == 4
+    assert examples["passed"] == 7
+    assert examples["total"] == 7
+    assert examples["available"] == 7
     assert examples["skipped"] == 0
     assert examples["run_live_example_enabled"] is True
-    assert inventory["default_example_count"] == 3
+    assert inventory["default_example_count"] == 6
     assert inventory["opt_in_example_count"] == 1

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -19,6 +19,20 @@ def _run_example(example_name: str, *, tmp_path: Path) -> subprocess.CompletedPr
     )
 
 
+def test_canonical_artifact_flow_example_executes(tmp_path: Path) -> None:
+    """The canonical flow should exercise the full public umbrella handoff."""
+    completed = _run_example("canonical_artifact_flow.py", tmp_path=tmp_path)
+    assert "Canonical artifact flow: canonical_artifact_flow" in completed.stdout
+    assert "Package path: problems -> agents -> experiments -> analysis" in completed.stdout
+    assert "Problem: Decision Problem - Student Laptop Design Under Choice-Based Demand" in (
+        completed.stdout
+    )
+    assert "Agent: SeededRandomBaselineAgent" in completed.stdout
+    assert "Runs: 2 (2 success)" in completed.stdout
+    assert "Mean primary_outcome:" in completed.stdout
+    assert "Event rows valid: True" in completed.stdout
+
+
 def test_student_laptop_design_study_example_executes(tmp_path: Path) -> None:
     """The student laptop study should report real packaged benchmark results."""
     completed = _run_example("student_laptop_design_study.py", tmp_path=tmp_path)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -54,6 +54,39 @@ def test_pump_and_battery_design_portfolio_example_executes(tmp_path: Path) -> N
     assert "Event rows valid: True" in completed.stdout
 
 
+def test_long_agent_markov_comparison_example_executes(tmp_path: Path) -> None:
+    """The long-process example should compare condition-specific Markov chains."""
+    completed = _run_example("long_agent_markov_comparison.py", tmp_path=tmp_path)
+    assert "Long agent Markov comparison: long_agent_markov_comparison" in completed.stdout
+    assert "Actions per run: 30" in completed.stdout
+    assert "Runs: 20" in completed.stdout
+    assert "Event rows valid: True" in completed.stdout
+    assert "Transition matrix delta:" in completed.stdout
+
+
+def test_model_size_sweep_regression_example_executes(tmp_path: Path) -> None:
+    """The model-size example should regress outcomes from artifacts."""
+    completed = _run_example("model_size_sweep_regression.py", tmp_path=tmp_path)
+    assert "Model size sweep regression: model_size_sweep_regression" in completed.stdout
+    assert "Model class: scripted-open-class" in completed.stdout
+    assert "Runs: 20" in completed.stdout
+    assert "Regression samples: 20" in completed.stdout
+    assert "Coefficient model_size_b:" in completed.stdout
+
+
+def test_partial_factorial_ideation_regression_example_executes(tmp_path: Path) -> None:
+    """The partial-factorial example should fit a linear model from artifacts."""
+    completed = _run_example("partial_factorial_ideation_regression.py", tmp_path=tmp_path)
+    assert (
+        "Partial factorial ideation regression: partial_factorial_ideation_regression"
+        in completed.stdout
+    )
+    assert "Conditions: 12" in completed.stdout
+    assert "Runs: 24" in completed.stdout
+    assert "Regression samples: 24" in completed.stdout
+    assert "Model size coefficient:" in completed.stdout
+
+
 def test_prompt_framing_walkthrough_uses_public_prompt_workflow_agent() -> None:
     """The live walkthrough should use the sibling-owned prompt workflow agent."""
     source = (EXAMPLES_DIR / "prompt_framing_study.py").read_text(encoding="utf-8")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -97,3 +97,15 @@ def test_prompt_framing_walkthrough_uses_public_prompt_workflow_agent() -> None:
     assert "build_json_prompt_workflow" in source
     assert "PromptWorkflowAgent" in source
     assert "agent_bindings" in source
+
+
+def test_examples_stay_on_public_artifact_helpers() -> None:
+    """Tutorial examples should not ask users to load raw analysis tables."""
+    combined_source = "\n".join(
+        path.read_text(encoding="utf-8") for path in sorted(EXAMPLES_DIR.glob("*.py"))
+    )
+
+    assert "analysis.integration" not in combined_source
+    assert "load_experiment_artifacts" not in combined_source
+    assert "build_condition_metric_table(" not in combined_source
+    assert "agent_result(" in combined_source

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -92,5 +92,8 @@ def test_prompt_framing_walkthrough_uses_public_prompt_workflow_agent() -> None:
     source = (EXAMPLES_DIR / "prompt_framing_study.py").read_text(encoding="utf-8")
     assert "_future_stack" not in source
     assert "_workspace_bootstrap" not in source
+    assert "build_json_model_workflow" not in source
+    assert "read_csv_rows" not in source
+    assert "build_json_prompt_workflow" in source
     assert "PromptWorkflowAgent" in source
     assert "agent_bindings" in source

--- a/tests/test_family_smoke.py
+++ b/tests/test_family_smoke.py
@@ -118,7 +118,6 @@ def test_april_family_interoperability_smoke(tmp_path: Path) -> None:
     run_results = dr.experiments.run_study(
         study,
         conditions=conditions,
-        problem_registry={problem_id: dr.experiments.resolve_problem(problem_id)},
         checkpoint=False,
         show_progress=False,
     )

--- a/tests/test_family_smoke.py
+++ b/tests/test_family_smoke.py
@@ -133,16 +133,13 @@ def test_april_family_interoperability_smoke(tmp_path: Path) -> None:
         validate_with_analysis_package=True,
     )
 
-    artifacts = dr.analysis.integration.load_experiment_artifacts(exported["events.csv"])
-    report = dr.analysis.integration.validate_experiment_events(exported["events.csv"])
-    metric_rows = dr.analysis.build_condition_metric_table(
-        artifacts["runs.csv"],
+    report = dr.analysis.validate_experiment_events(exported["events.csv"])
+    metric_rows = dr.analysis.build_condition_metric_table_from_artifacts(
+        exported["events.csv"],
         metric="primary_outcome",
         condition_column="agent_id",
-        conditions=artifacts["conditions.csv"],
-        evaluations=artifacts["evaluations.csv"],
     )
 
     assert report.is_valid
-    assert artifacts["manifest.json"]["study_id"] == study.study_id
+    assert exported["manifest.json"].exists()
     assert metric_rows


### PR DESCRIPTION
## Summary
- add a concise deterministic `canonical_artifact_flow.py` example for the problems -> agents -> experiments -> analysis handoff
- document the example as the no-network compatibility smoke path
- remove local problem-registry and validation wrapper plumbing from existing examples/tests where public APIs already handle it

## Validation
- `python scripts/run_examples.py` with adjacent sibling editables
- `python -m pytest tests/test_examples.py tests/test_example_tooling.py tests/test_family_smoke.py -q` with adjacent sibling editables
- `python scripts/check_docs_consistency.py`
- `python scripts/check_example_api_coverage.py --minimum 90`
- `make docs-build`
- `ruff check examples tests docs src scripts`
- `ruff format --check examples tests docs src scripts`

Closes #15