### PR TITLE
[codex] Prepare Legend Line release version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 <!-- release-callout:start -->
 > [!IMPORTANT]
-> Current monthly release: [Compass Course - May 2026](https://github.com/cmudrc/design-research/milestone/3)  
-> Due: June 8, 2026  
-> Tracks: May 2026 work
+> Current monthly release: [Legend Line - June 2026](https://github.com/cmudrc/design-research/milestone/4)  
+> Due: July 8, 2026  
+> Tracks: June 2026 work
 <!-- release-callout:end -->
 
 `design-research` is the umbrella entry-point package in the cmudrc design

--- a/docs/compatibility.rst
+++ b/docs/compatibility.rst
@@ -20,17 +20,17 @@ Tested Package Combination
      - ``design-research-experiments``
      - ``design-research-analysis``
      - Monthly release context
-   * - ``0.3.0``
+   * - ``0.3.1``
      - ``0.3.0``
      - ``0.4.0``
      - ``0.2.0``
      - ``0.2.0``
-     - ``Compass Course - May 2026``
+     - ``Legend Line - June 2026``
 
 These versions match the exact sibling pins in ``pyproject.toml`` and represent
 the tested umbrella combination for the current docs baseline.
 
-The bundled examples and smoke tests intentionally target the May 2026 family
+The bundled examples and smoke tests intentionally target the June 2026 family
 interop seams directly. :doc:`canonical_artifact_flow` is the no-network smoke
 path: it resolves a packaged problem, runs the public seeded baseline agent,
 exports canonical experiment artifacts, and validates them with

--- a/src/design_research/_version.py
+++ b/src/design_research/_version.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from design_research import _lazy
@@ -12,6 +14,21 @@ def test_module_dir_includes_public_and_existing_names() -> None:
     """module_dir should merge globals and public names without duplicates."""
     names = _lazy.module_dir({"alpha": object(), "beta": object()}, ["beta", "gamma"])
     assert names == ["alpha", "beta", "gamma"]
+
+
+def test_public_module_exports_falls_back_to_non_private_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Modules without __all__ should export visible attributes only."""
+    module = SimpleNamespace(alpha=object(), beta=object(), _private=object())
+    monkeypatch.setattr(_lazy, "import_module", lambda _module_path: module)
+
+    exports = _lazy.public_module_exports("example.module")
+
+    assert exports == {
+        "alpha": "example.module:alpha",
+        "beta": "example.module:beta",
+    }
 
 
 def test_resolve_lazy_export_raises_attribute_error_for_unknown_name() -> None:

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -46,4 +46,4 @@ def test_wrapper_dir_exposes_lazy_exports() -> None:
 
 def test_version_module_exposes_single_source_of_truth() -> None:
     """Version module should expose the next release version directly."""
-    assert __version__ == "0.3.0"
+    assert __version__ == "0.3.1"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -34,4 +34,4 @@ def test_top_level_namespace_does_not_flatten_wrapper_symbols() -> None:
 
 def test_package_version_is_exposed_from_the_top_level() -> None:
     """Expose package metadata without requiring installed distribution metadata."""
-    assert dr.__version__ == "0.3.0"
+    assert dr.__version__ == "0.3.1"


### PR DESCRIPTION
## Summary
- bump the umbrella package version from 0.3.0 to 0.3.1
- update the README release callout and compatibility docs for Legend Line - June 2026

## June closeout scope
Legend Line is now scoped to release cleanup after moving broader maintenance work forward:

- #22 and #13 were moved to Bearing Bridge - July 2026.
- #5 was moved to Surveyor Signal - August 2026.
- Sibling dependency pins intentionally remain on the latest published May releases until the June sibling packages are published.

## Validation
- uv run --extra dev make qa
