### PR TITLE
Install Pandoc for notebook docs

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -2,6 +2,7 @@ name: Docs
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -28,6 +28,12 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install Pandoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes pandoc
+          pandoc --version
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- install Pandoc explicitly in the GitHub Pages build job
- run the docs build on pull requests while keeping upload and deployment main-only

## Validation
- `actionlint .github/workflows/docs-pages.yml`
- warning-as-error 22-page Sphinx build with all six notebook tutorials

Closes #28