### PR TITLE
Add public self-guided learning path

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ example workflow, see
 
 Choose your entry point based on how much of the ecosystem you need:
 
+- Start with the [public learning path](https://cmudrc.github.io/design-research/learn.html) when you want to learn through guided tutorials and optional open-source contribution.
 - Start with `design-research` when you want one stable namespace and one set of docs across problems, agents, experiments, and analysis.
 - Install a sibling package directly when you only need one layer or want package-specific internals; direct sibling use is fully supported.
 - See [Compatibility and Start Here](https://cmudrc.github.io/design-research/compatibility.html) for the tested package combination and install guidance.

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -217,6 +217,47 @@ button.copybtn:hover {
   font-weight: 700;
 }
 
+.drc-learning-hero,
+.drc-learning-finish {
+  margin: 1.5rem 0 2rem;
+  padding: 1.25rem 1.4rem;
+  border: 1px solid transparent;
+  border-radius: 1.15rem;
+  background:
+    linear-gradient(135deg, var(--drc-panel-elevated), var(--drc-panel-bg)) padding-box,
+    var(--drc-brand-gradient) border-box;
+}
+
+.drc-learning-hero p,
+.drc-learning-finish p {
+  margin-bottom: 0.6rem;
+}
+
+.drc-learning-hero p:last-child,
+.drc-learning-finish p:last-child {
+  margin-bottom: 0;
+}
+
+.drc-learning-hero a {
+  display: inline-flex;
+  margin: 0.25rem 0.65rem 0.15rem 0;
+  padding: 0.55rem 0.8rem;
+  border: 1px solid var(--drc-brand-border);
+  border-radius: 999px;
+  background: var(--drc-panel-bg);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.drc-learning-hero a:hover {
+  border-color: var(--drc-brand-strong);
+  background: var(--drc-brand-soft);
+}
+
+.drc-learning-finish {
+  border-left-color: var(--drc-brand-strong);
+}
+
 .drc-home-ecosystem {
   margin: 1.75rem 0 2rem;
   padding: 1rem;
@@ -246,7 +287,9 @@ html[data-theme="dark"] .bd-content img.drc-ecosystem-figure {
   }
 
   .drc-home-badges,
-  .drc-home-ecosystem {
+  .drc-home-ecosystem,
+  .drc-learning-hero,
+  .drc-learning-finish {
     padding: 0.85rem;
   }
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,9 +52,9 @@ focused notebooks' displayed results still match their source.
 
    .. note::
 
-      **Start with** :doc:`compatibility` to choose between the umbrella package
-      and direct sibling installs, then follow :doc:`tutorials/index` from one
-      library through the deterministic all-layer handoff.
+      **New to computational design research?** Follow the public,
+      self-guided :doc:`learning path <learn>`. Run a tutorial, extend an
+      example, and contribute only if doing so supports your learning.
 
 Tutorial Series
 ---------------
@@ -78,6 +78,7 @@ Guides
 Use these pages to understand the umbrella package, the shared namespace, and
 the recommended path through the ecosystem.
 
+- :doc:`learn`
 - :doc:`compatibility`
 - :doc:`tutorials/index`
 - :doc:`canonical_artifact_flow`
@@ -123,6 +124,7 @@ study design through execution and interpretation.
 Start Here
 ----------
 
+- :doc:`learn`
 - :doc:`compatibility`
 - :doc:`canonical_artifact_flow`
 - :doc:`prompt_framing_study`
@@ -139,6 +141,7 @@ Start Here
    :maxdepth: 2
    :hidden:
 
+   learn
    compatibility
    tutorials/index
    canonical_artifact_flow

--- a/docs/learn.rst
+++ b/docs/learn.rst
@@ -1,0 +1,143 @@
+Learn With ``design-research``
+================================
+
+Learn computational design research by using the same open-source tools that
+support work in the Design Research Collective. Start with a runnable tutorial,
+change an example when you are ready, and keep what you build. Sharing a patch
+or pull request is always optional.
+
+.. container:: drc-learning-hero
+
+   **The tutorials are the opportunity.** You do not need to apply, join a
+   cohort, or contact the lab before starting.
+
+   :doc:`Choose a tutorial <tutorials/index>` | :doc:`Set up VS Code <vscode_start>`
+
+What This Path Is
+-----------------
+
+This is a public, self-guided learning path for anyone comfortable trying
+Python. It is not an internship, supervised research placement, or admissions
+process. There are no deadlines, meetings, certificates, or required
+contributions.
+
+Completing a tutorial or opening a contribution does not imply individual
+feedback, mentorship, lab membership, a recommendation, or a future position.
+Issues and pull requests enter the same open-source review process as every
+other contribution. Review and acceptance depend on project fit and maintainer
+availability.
+
+You do not need to tell us your age, school, or reason for using the materials.
+Do not include private information, credentials, school records, participant
+data, or sponsor data in an issue or contribution.
+
+Your Learning Path
+------------------
+
+1. Run One Example
+~~~~~~~~~~~~~~~~~~
+
+Install the published ``design-research`` package and confirm that you can load
+a packaged problem. The :doc:`VS Code setup guide <vscode_start>` provides the
+most direct first-user path. Python 3.12 or newer is required.
+
+If you already work comfortably from a terminal, use the
+:doc:`quickstart` instead.
+
+2. Choose A Tutorial
+~~~~~~~~~~~~~~~~~~~~
+
+All tutorials include runnable source material and displayed results. Most run
+offline. The local-model tutorial is clearly marked and can be skipped.
+
+.. list-table:: Choose by what you want to learn
+   :header-rows: 1
+   :widths: 22 34 30 14
+
+   * - Track
+     - Start here
+     - What you will practice
+     - Runtime
+   * - Design problems
+     - :doc:`Map packaged text problems <tutorials/problems_text_map>`
+     - Loading a research corpus, representing text, and interpreting a map
+     - Offline
+   * - Design grammars
+     - :doc:`Explore a truss grammar <tutorials/problems_truss_grammar>`
+     - Applying rules and inspecting a structured design state
+     - Offline
+   * - Agent workflows
+     - :doc:`Build a deterministic workflow <tutorials/agents_workflow>`
+     - Composing and tracing a small reasoning process
+     - Offline
+   * - Experiments
+     - :doc:`Test a Monty Hall strategy <tutorials/experiments_monty_hall>`
+     - Conditions, replication, seeding, and reproducible results
+     - Offline
+   * - Analysis
+     - :doc:`Measure coder reliability <tutorials/analysis_reliability>`
+     - Preparing observations and quantifying agreement
+     - Offline
+   * - Complete workflow
+     - :doc:`Run a full-stack study <tutorials/full_stack_study>`
+     - Connecting problems, agents, experiments, and analysis
+     - Offline
+   * - Local AI models
+     - :doc:`Try propose/critic <tutorials/agents_propose_critic>`
+     - Running and comparing a model-backed agent pattern
+     - Ollama
+
+The :doc:`complete tutorial index <tutorials/index>` includes additional
+process-comparison and factorial-analysis paths.
+
+3. Make The Example Yours
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Once an example runs unchanged, make one deliberate extension. For example:
+
+- select a different packaged problem;
+- change an experimental condition or number of replications;
+- add a small deterministic agent step;
+- compare another metric or visualization; or
+- improve an explanation that was difficult to follow.
+
+Record what you changed, what you expected, and what happened. A working
+extension and a short explanation are a complete learning outcome. You do not
+need to submit them anywhere.
+
+4. Contribute If It Helps Your Learning
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If your extension fixes a defect or improves the project for other users, you
+may choose to share it:
+
+1. Read the `contribution guide <https://github.com/cmudrc/design-research/blob/HEAD/CONTRIBUTING.md>`_.
+2. Keep the change focused and explain the user-facing improvement.
+3. Run the checks requested by the repository you changed.
+4. Open a pull request through the repository's normal GitHub workflow.
+
+A pull request is a proposed improvement, not an application. It may be
+discussed, revised, declined, or remain unmerged. The value of the learning
+path does not depend on that outcome.
+
+Where The Libraries Fit
+-----------------------
+
+The umbrella package connects four focused libraries:
+
+- `design-research-problems <https://github.com/cmudrc/design-research-problems>`_
+  provides prompts, design tasks, grammars, benchmarks, and evaluators.
+- `design-research-agents <https://github.com/cmudrc/design-research-agents>`_
+  provides AI participants, workflows, tools, and traceable reasoning patterns.
+- `design-research-experiments <https://github.com/cmudrc/design-research-experiments>`_
+  defines hypotheses, conditions, replications, and study artifacts.
+- `design-research-analysis <https://github.com/cmudrc/design-research-analysis>`_
+  supports sequence, language, embedding, and statistical analysis.
+
+Begin with the umbrella tutorials. Move into a component repository only when
+you want to understand or change that layer in more detail.
+
+.. container:: drc-learning-finish
+
+   **A successful first step is simple:** run one tutorial, change one thing,
+   and explain what you learned.


### PR DESCRIPTION
## Summary

- add a public, age-neutral learning page that connects the existing tutorials into a self-guided progression
- make optional contribution and maintainer-availability boundaries explicit
- link the learning path from the documentation home and repository README
- add responsive styling for the page's start and completion callouts

## Why

Interested learners need one canonical entry point that helps them use the open-source ecosystem without implying an internship, cohort, mentorship relationship, or expectation of free work. The tutorials are the primary opportunity; opening a patch or pull request is an optional next step.

## Validation

- `make docs-check`
- `make docs`
- verified the rendered page structure and representative internal tutorial links
