### PR TITLE
Refine learning path presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ example workflow, see
 
 Choose your entry point based on how much of the ecosystem you need:
 
-- Start with the [public learning path](https://cmudrc.github.io/design-research/learn.html) when you want to learn through guided tutorials and optional open-source contribution.
+- Start with the [Learning Path](https://cmudrc.github.io/design-research/learn.html) for a guided progression through the tutorials.
 - Start with `design-research` when you want one stable namespace and one set of docs across problems, agents, experiments, and analysis.
 - Install a sibling package directly when you only need one layer or want package-specific internals; direct sibling use is fully supported.
 - See [Compatibility and Start Here](https://cmudrc.github.io/design-research/compatibility.html) for the tested package combination and install guidance.

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -217,8 +217,7 @@ button.copybtn:hover {
   font-weight: 700;
 }
 
-.drc-learning-hero,
-.drc-learning-finish {
+.drc-learning-hero {
   margin: 1.5rem 0 2rem;
   padding: 1.25rem 1.4rem;
   border: 1px solid transparent;
@@ -228,13 +227,11 @@ button.copybtn:hover {
     var(--drc-brand-gradient) border-box;
 }
 
-.drc-learning-hero p,
-.drc-learning-finish p {
+.drc-learning-hero p {
   margin-bottom: 0.6rem;
 }
 
-.drc-learning-hero p:last-child,
-.drc-learning-finish p:last-child {
+.drc-learning-hero p:last-child {
   margin-bottom: 0;
 }
 
@@ -252,10 +249,6 @@ button.copybtn:hover {
 .drc-learning-hero a:hover {
   border-color: var(--drc-brand-strong);
   background: var(--drc-brand-soft);
-}
-
-.drc-learning-finish {
-  border-left-color: var(--drc-brand-strong);
 }
 
 .drc-home-ecosystem {
@@ -288,8 +281,77 @@ html[data-theme="dark"] .bd-content img.drc-ecosystem-figure {
 
   .drc-home-badges,
   .drc-home-ecosystem,
-  .drc-learning-hero,
-  .drc-learning-finish {
+  .drc-learning-hero {
     padding: 0.85rem;
+  }
+
+  .drc-learning-table table,
+  .drc-learning-table tbody,
+  .drc-learning-table tr,
+  .drc-learning-table td {
+    display: block;
+    width: 100%;
+  }
+
+  .drc-learning-table thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .drc-learning-table table {
+    border: 0;
+    background: transparent;
+  }
+
+  .drc-learning-table caption {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    text-align: left;
+    font-weight: 700;
+  }
+
+  .drc-learning-table tbody tr {
+    margin: 0 0 0.85rem;
+    padding: 0.4rem 0;
+    border: 1px solid var(--drc-brand-border);
+    border-radius: 0.85rem;
+    background: var(--drc-panel-bg);
+  }
+
+  .drc-learning-table tbody td {
+    display: grid;
+    grid-template-columns: minmax(5.5rem, 0.34fr) minmax(0, 1fr);
+    gap: 0.75rem;
+    padding: 0.4rem 0.7rem;
+    border: 0;
+  }
+
+  .drc-learning-table tbody td::before {
+    color: var(--pst-color-text-muted);
+    font-weight: 700;
+  }
+
+  .drc-learning-table tbody td:nth-child(1)::before {
+    content: "Track";
+  }
+
+  .drc-learning-table tbody td:nth-child(2)::before {
+    content: "Start here";
+  }
+
+  .drc-learning-table tbody td:nth-child(3)::before {
+    content: "Practice";
+  }
+
+  .drc-learning-table tbody td:nth-child(4)::before {
+    content: "Runtime";
   }
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,7 +85,7 @@ html_css_files = ["custom.css"]
 html_logo = "_static/drc-light.png"
 html_favicon = "_static/favicon.ico"
 html_title = project
-html_sidebars = {"index": []} if html_theme == "pydata_sphinx_theme" else {}
+html_sidebars = {"index": [], "learn": []} if html_theme == "pydata_sphinx_theme" else {}
 
 _VIEWPORT_META_RE = re.compile(r'<meta name="viewport"[^>]*>', re.IGNORECASE)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,9 +52,9 @@ focused notebooks' displayed results still match their source.
 
    .. note::
 
-      **New to computational design research?** Follow the public,
-      self-guided :doc:`learning path <learn>`. Run a tutorial, extend an
-      example, and contribute only if doing so supports your learning.
+      **New to computational design research?** Follow the
+      :doc:`Learning Path <learn>` from a first tutorial through a complete
+      experiment and analysis workflow.
 
 Tutorial Series
 ---------------

--- a/docs/learn.rst
+++ b/docs/learn.rst
@@ -1,38 +1,19 @@
-Learn With ``design-research``
-================================
+Learning Path
+=============
 
-Learn computational design research by using the same open-source tools that
-support work in the Design Research Collective. Start with a runnable tutorial,
-change an example when you are ready, and keep what you build. Sharing a patch
-or pull request is always optional.
+Explore computational design research with the open-source tools developed by
+the Design Research Collective. Start with a runnable tutorial, adapt an
+example, and follow the parts of the ecosystem that match your interests.
 
 .. container:: drc-learning-hero
 
-   **The tutorials are the opportunity.** You do not need to apply, join a
-   cohort, or contact the lab before starting.
+   Start with a tutorial. Extend an example. Share an improvement if it is
+   useful to others.
 
-   :doc:`Choose a tutorial <tutorials/index>` | :doc:`Set up VS Code <vscode_start>`
+   :doc:`Choose a tutorial <tutorials/index>` :doc:`Set up VS Code <vscode_start>`
 
-What This Path Is
------------------
-
-This is a public, self-guided learning path for anyone comfortable trying
-Python. It is not an internship, supervised research placement, or admissions
-process. There are no deadlines, meetings, certificates, or required
-contributions.
-
-Completing a tutorial or opening a contribution does not imply individual
-feedback, mentorship, lab membership, a recommendation, or a future position.
-Issues and pull requests enter the same open-source review process as every
-other contribution. Review and acceptance depend on project fit and maintainer
-availability.
-
-You do not need to tell us your age, school, or reason for using the materials.
-Do not include private information, credentials, school records, participant
-data, or sponsor data in an issue or contribution.
-
-Your Learning Path
-------------------
+Four Steps
+----------
 
 1. Run One Example
 ~~~~~~~~~~~~~~~~~~
@@ -50,42 +31,44 @@ If you already work comfortably from a terminal, use the
 All tutorials include runnable source material and displayed results. Most run
 offline. The local-model tutorial is clearly marked and can be skipped.
 
-.. list-table:: Choose by what you want to learn
-   :header-rows: 1
-   :widths: 22 34 30 14
+.. container:: drc-learning-table
 
-   * - Track
-     - Start here
-     - What you will practice
-     - Runtime
-   * - Design problems
-     - :doc:`Map packaged text problems <tutorials/problems_text_map>`
-     - Loading a research corpus, representing text, and interpreting a map
-     - Offline
-   * - Design grammars
-     - :doc:`Explore a truss grammar <tutorials/problems_truss_grammar>`
-     - Applying rules and inspecting a structured design state
-     - Offline
-   * - Agent workflows
-     - :doc:`Build a deterministic workflow <tutorials/agents_workflow>`
-     - Composing and tracing a small reasoning process
-     - Offline
-   * - Experiments
-     - :doc:`Test a Monty Hall strategy <tutorials/experiments_monty_hall>`
-     - Conditions, replication, seeding, and reproducible results
-     - Offline
-   * - Analysis
-     - :doc:`Measure coder reliability <tutorials/analysis_reliability>`
-     - Preparing observations and quantifying agreement
-     - Offline
-   * - Complete workflow
-     - :doc:`Run a full-stack study <tutorials/full_stack_study>`
-     - Connecting problems, agents, experiments, and analysis
-     - Offline
-   * - Local AI models
-     - :doc:`Try propose/critic <tutorials/agents_propose_critic>`
-     - Running and comparing a model-backed agent pattern
-     - Ollama
+   .. list-table:: Choose by what you want to learn
+      :header-rows: 1
+      :widths: 22 34 30 14
+
+      * - Track
+        - Start here
+        - What you will practice
+        - Runtime
+      * - Design problems
+        - :doc:`Map packaged text problems <tutorials/problems_text_map>`
+        - Loading a research corpus, representing text, and interpreting a map
+        - Offline
+      * - Design grammars
+        - :doc:`Explore a truss grammar <tutorials/problems_truss_grammar>`
+        - Applying rules and inspecting a structured design state
+        - Offline
+      * - Agent workflows
+        - :doc:`Build a deterministic workflow <tutorials/agents_workflow>`
+        - Composing and tracing a small reasoning process
+        - Offline
+      * - Experiments
+        - :doc:`Test a Monty Hall strategy <tutorials/experiments_monty_hall>`
+        - Conditions, replication, seeding, and reproducible results
+        - Offline
+      * - Analysis
+        - :doc:`Measure coder reliability <tutorials/analysis_reliability>`
+        - Preparing observations and quantifying agreement
+        - Offline
+      * - Complete workflow
+        - :doc:`Run a full-stack study <tutorials/full_stack_study>`
+        - Connecting problems, agents, experiments, and analysis
+        - Offline
+      * - Local AI models
+        - :doc:`Try propose/critic <tutorials/agents_propose_critic>`
+        - Running and comparing a model-backed agent pattern
+        - Ollama
 
 The :doc:`complete tutorial index <tutorials/index>` includes additional
 process-comparison and factorial-analysis paths.
@@ -102,23 +85,21 @@ Once an example runs unchanged, make one deliberate extension. For example:
 - improve an explanation that was difficult to follow.
 
 Record what you changed, what you expected, and what happened. A working
-extension and a short explanation are a complete learning outcome. You do not
-need to submit them anywhere.
+extension and a short explanation are a complete learning outcome.
 
-4. Contribute If It Helps Your Learning
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+4. Share An Improvement
+~~~~~~~~~~~~~~~~~~~~~~~
 
-If your extension fixes a defect or improves the project for other users, you
-may choose to share it:
+If your extension could help other users, share it through the usual
+open-source workflow:
 
 1. Read the `contribution guide <https://github.com/cmudrc/design-research/blob/HEAD/CONTRIBUTING.md>`_.
 2. Keep the change focused and explain the user-facing improvement.
 3. Run the checks requested by the repository you changed.
 4. Open a pull request through the repository's normal GitHub workflow.
 
-A pull request is a proposed improvement, not an application. It may be
-discussed, revised, declined, or remain unmerged. The value of the learning
-path does not depend on that outcome.
+Contributions are reviewed for project fit and may be revised before they are
+accepted.
 
 Where The Libraries Fit
 -----------------------
@@ -136,8 +117,3 @@ The umbrella package connects four focused libraries:
 
 Begin with the umbrella tutorials. Move into a component repository only when
 you want to understand or change that layer in more detail.
-
-.. container:: drc-learning-finish
-
-   **A successful first step is simple:** run one tutorial, change one thing,
-   and explain what you learned.


### PR DESCRIPTION
## Summary

- simplify the page into a straightforward four-step learning path
- remove internship, cohort, admissions, and lab-contact framing
- widen the desktop content area by removing the empty section sidebar
- render the tutorial comparison as readable cards on mobile
- simplify the homepage and README entry-point language

## Why

The first version overexplained the context behind the page and used policy-oriented language that distracted from the tutorials. Its desktop layout also reserved space for an empty sidebar, while the four-column tutorial table was clipped on mobile.

## Validation

- `make docs-check`
- `make docs`
- `make ci`
- visually reviewed the rendered page at 1440 x 1000 and 390 x 844
