### PR TITLE
Transpose compatibility matrix

### DIFF
--- a/docs/compatibility.rst
+++ b/docs/compatibility.rst
@@ -13,16 +13,19 @@ Tested Package Combination
 
 .. list-table:: Version-first compatibility matrix
    :header-rows: 1
+   :widths: 72 28
 
+   * - Package
+     - Version
    * - ``design-research``
-     - ``design-research-problems``
-     - ``design-research-agents``
-     - ``design-research-experiments``
-     - ``design-research-analysis``
-   * - ``0.4.0``
      - ``0.4.0``
+   * - ``design-research-problems``
+     - ``0.4.0``
+   * - ``design-research-agents``
      - ``0.6.0``
+   * - ``design-research-experiments``
      - ``0.3.0``
+   * - ``design-research-analysis``
      - ``0.3.1``
 
 These versions match the exact sibling pins in ``pyproject.toml`` and represent


### PR DESCRIPTION
## What changed

- Transposed the version-first compatibility matrix so packages are rows and versions are columns.
- Added explicit Package and Version headers with responsive column widths.

## Why

The previous five-column layout was clipped on desktop and especially difficult to scan on mobile. The vertical layout keeps every package name and version visible without horizontal scrolling.

## Validation

- `make docs-check`
- `make docs`
- Desktop visual review at 1440 px
- Mobile visual review at 390 px
- `make ci`
