### PR TITLE
Simplify docs navigation

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -31,7 +31,10 @@ jobs:
 
       - name: Install Pandoc
         run: |
-          sudo apt-get update
+          if [[ -f /etc/apt/apt-mirrors.txt ]]; then
+            sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' /etc/apt/apt-mirrors.txt
+          fi
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::https::Timeout=30 update
           sudo apt-get install --yes pandoc
           pandoc --version
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,7 @@ else:
             },
         ],
         "navbar_align": "content",
-        "header_links_before_dropdown": 4,
+        "header_links_before_dropdown": 3,
         "show_nav_level": 2,
         "navigation_with_keys": True,
         "show_prev_next": False,
@@ -85,7 +85,9 @@ html_css_files = ["custom.css"]
 html_logo = "_static/drc-light.png"
 html_favicon = "_static/favicon.ico"
 html_title = project
-html_sidebars = {"index": [], "learn": []} if html_theme == "pydata_sphinx_theme" else {}
+html_sidebars = (
+    {"index": [], "learn": [], "guides": []} if html_theme == "pydata_sphinx_theme" else {}
+)
 
 _VIEWPORT_META_RE = re.compile(r'<meta name="viewport"[^>]*>', re.IGNORECASE)
 

--- a/docs/guides.rst
+++ b/docs/guides.rst
@@ -1,0 +1,53 @@
+Guides
+======
+
+Find setup instructions, ecosystem concepts, complete workflow examples, and
+technical reference for ``design-research``.
+
+Get Started
+-----------
+
+- :doc:`installation` — install the umbrella package and optional extras.
+- :doc:`quickstart` — load the package and run a first example.
+- :doc:`vscode_start` — set up and run an example in VS Code.
+- :doc:`compatibility` — check the tested package combination and choose
+  between the umbrella package and a sibling library.
+
+Understand The Ecosystem
+------------------------
+
+- :doc:`concepts` — learn the shared vocabulary and package boundaries.
+- :doc:`typical_workflow` — see how the libraries fit into a research study.
+- :doc:`philosophy` — understand the umbrella package's design principles.
+
+Follow Complete Workflows
+-------------------------
+
+- :doc:`canonical_artifact_flow` — trace an offline workflow across all four
+  libraries.
+- :doc:`prompt_framing_study` — run the local-model comparison walkthrough.
+
+Technical Reference
+-------------------
+
+- :doc:`api` — inspect the stable public namespace.
+- :doc:`dependencies_and_extras` — review dependency groups and optional
+  tooling.
+- `Contributing guide <https://github.com/cmudrc/design-research/blob/HEAD/CONTRIBUTING.md>`_
+  — prepare a focused change for review.
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   installation
+   quickstart
+   vscode_start
+   compatibility
+   concepts
+   typical_workflow
+   philosophy
+   canonical_artifact_flow
+   prompt_framing_study
+   api
+   dependencies_and_extras

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,25 +79,8 @@ Use these pages to understand the umbrella package, the shared namespace, and
 the recommended path through the ecosystem.
 
 - :doc:`learn`
-- :doc:`compatibility`
 - :doc:`tutorials/index`
-- :doc:`canonical_artifact_flow`
-- :doc:`prompt_framing_study`
-- :doc:`vscode_start`
-- :doc:`quickstart`
-- :doc:`installation`
-- :doc:`concepts`
-- :doc:`typical_workflow`
-- :doc:`philosophy`
-
-Reference
----------
-
-Look up the stable re-export surface and the extras that shape development and
-documentation workflows.
-
-- :doc:`api`
-- :doc:`dependencies_and_extras`
+- :doc:`guides`
 
 Integration With The Ecosystem
 ------------------------------
@@ -121,36 +104,10 @@ study design through execution and interpretation.
       :width: 100%
       :align: center
 
-Start Here
-----------
-
-- :doc:`learn`
-- :doc:`compatibility`
-- :doc:`canonical_artifact_flow`
-- :doc:`prompt_framing_study`
-- :doc:`vscode_start`
-- :doc:`quickstart`
-- :doc:`installation`
-- :doc:`concepts`
-- :doc:`typical_workflow`
-- :doc:`api`
-- :doc:`philosophy`
-- `CONTRIBUTING.md <https://github.com/cmudrc/design-research/blob/HEAD/CONTRIBUTING.md>`_
-
 .. toctree::
    :maxdepth: 2
    :hidden:
 
    learn
-   compatibility
    tutorials/index
-   canonical_artifact_flow
-   prompt_framing_study
-   vscode_start
-   quickstart
-   installation
-   concepts
-   typical_workflow
-   philosophy
-   api
-   dependencies_and_extras
+   guides


### PR DESCRIPTION
## What changed

- Reduced the global documentation navigation to Learning Path, Tutorials, and Guides.
- Removed the overloaded More dropdown.
- Added a Guides hub that groups setup, ecosystem concepts, complete workflows, and technical reference.
- Removed duplicated long link lists from the homepage.
- Routed the docs workflow around the GitHub runner's timing-out Azure Ubuntu mirror with bounded retries.

## Why

The previous header exposed four long primary links plus a nine-item overflow menu. On mobile, the site drawer presented thirteen undifferentiated destinations. The new hierarchy keeps the global choices small while preserving every page through a grouped hub and search.

The first hosted docs attempt stalled for sixteen minutes while `apt-get update` repeatedly timed out against `azure.archive.ubuntu.com`. The workflow now uses Ubuntu's main archive when the runner mirror list is present.

## User impact

Readers can choose a learning path, browse tutorials, or look up guidance without parsing the full documentation tree. Detailed pages remain available from the Guides hub.

## Validation

- `make docs-check`
- `make docs`
- `make ci`
- Workflow YAML validation
- Desktop visual comparison at 1440 px
- Mobile navigation comparison at 390 px
