### PR TITLE
Restore learning callout padding

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -217,7 +217,7 @@ button.copybtn:hover {
   font-weight: 700;
 }
 
-.drc-learning-hero {
+.drc-learning-hero.docutils.container {
   margin: 1.5rem 0 2rem;
   padding: 1.25rem 1.4rem;
   border: 1px solid transparent;
@@ -281,7 +281,7 @@ html[data-theme="dark"] .bd-content img.drc-ecosystem-figure {
 
   .drc-home-badges,
   .drc-home-ecosystem,
-  .drc-learning-hero {
+  .drc-learning-hero.docutils.container {
     padding: 0.85rem;
   }
 


### PR DESCRIPTION
## What changed

- Increased selector specificity for the learning-path callout at desktop and mobile breakpoints.
- Restored the existing intended horizontal padding without changing the component's copy, actions, border, or color treatment.

## Why

The PyData theme's `.docutils.container` rule had higher specificity than the custom callout selector, so it reset horizontal padding to zero. The callout content therefore sat directly against its border.

## Impact

The callout now has a deliberate inner inset on desktop and mobile while preserving its responsive layout and working links.

## Validation

- `make docs-check`
- `make docs`
- `make ci`
- Browser review in dark mode at 1994×900 and 390×844
- Measured desktop padding: `20px 22.4px`
- Measured mobile padding: `13.6px`
- Both callout links verified
- No horizontal overflow or console errors