### PR TITLE
Remove redundant tutorial table caption

### DIFF
--- a/docs/learn.rst
+++ b/docs/learn.rst
@@ -33,7 +33,7 @@ offline. The local-model tutorial is clearly marked and can be skipped.
 
 .. container:: drc-learning-table
 
-   .. list-table:: Choose by what you want to learn
+   .. list-table::
       :header-rows: 1
       :widths: 22 34 30 14
 


### PR DESCRIPTION
## What changed

Removed the caption above the learning-path tutorial table.

## Why

The caption repeated the surrounding “Choose A Tutorial” section heading and used conversational wording where the column headers already make the table’s purpose clear.

## Impact

The table now begins directly with its conventional column headers: Track, Start here, What you will practice, and Runtime.

## Validation

- `make docs-check`
- `make docs`
- Confirmed the removed caption is absent from the generated HTML
- `make ci`