### PR TITLE
Improve tutorial first-run flow and live smoke checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,8 @@ merging.
   - `make docs-check`
   - `make docs`
 - If the example changed:
-  - `make run-example` (install `llama-cpp-python[server]`; also install `huggingface-hub` unless `LLAMA_CPP_MODEL` points at a local GGUF file)
   - `make examples-test` (live examples require their runtime-specific opt-in variable)
+  - `make live-smoke` for a focused semantic check of both live tutorials (or use the runtime-specific `make live-smoke-ollama` and `make live-smoke-llama-cpp` targets)
 - Pre-merge baseline:
   - `make ci`
 - Pre-publish baseline:
@@ -51,6 +51,7 @@ merging.
 ## Behavioral Guardrails
 
 - Keep tests deterministic and offline by default.
+- Run `make live-smoke` periodically and before releases on model-capable infrastructure; do not make the default CI loop depend on local model services.
 - Let the canonical walkthrough fail fast when the `llama.cpp` runtime is missing rather than silently falling back.
 - Keep total line coverage at or above 95% in CI and local release work.
 - Update tests, docs, and examples alongside behavior changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,8 +61,8 @@ make docs
 If the example or walkthrough docs changed, also run:
 
 ```bash
-make run-example
 make examples-test
+make live-smoke
 ```
 
 `make run-example` is the live walkthrough path and uses a managed
@@ -73,6 +73,13 @@ GGUF file. Set `RUN_LLAMA_CPP_EXAMPLES=1` to include that walkthrough in
 `make examples-test`. Set `RUN_OLLAMA_EXAMPLES=1` independently for the
 Ollama-backed propose/critic notebook. Both remain opt-in so the default local
 and CI loop stays offline-safe.
+
+`make live-smoke` is the focused semantic gate for both live tutorials. It
+runs the Ollama notebook once and uses two replicates per condition for the
+managed llama.cpp study. Run `make live-smoke-ollama` or
+`make live-smoke-llama-cpp` if only one runtime is provisioned. Run the
+combined target periodically and before releases on model-capable
+infrastructure; it is intentionally separate from offline CI.
 
 `make examples-test` records one result per discovered file in
 `artifacts/examples/example_results.json`; badge generation rejects evidence

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,12 @@ SPHINX ?= $(PYTHON) -m sphinx
 BUILD ?= $(PYTHON) -m build
 TWINE ?= $(PYTHON) -m twine
 COVERAGE_MIN ?= 95
+LIVE_SMOKE_REPLICATES ?= 2
 
 .PHONY: help check-python dev install-dev \
 	lint fmt fmt-check type test qa coverage docstrings-check \
-	run-example examples-test examples-coverage examples-metrics notebooks-check notebooks-refresh notebooks-type \
+	run-example live-smoke live-smoke-ollama live-smoke-llama-cpp \
+	examples-test examples-coverage examples-metrics notebooks-check notebooks-refresh notebooks-type \
 	idetc2026-bundle idetc2026-bundle-check docs docs-build docs-check docs-linkcheck \
 	release-check ci clean
 
@@ -20,6 +22,9 @@ help:
 	@echo "  test             Run the pytest suite."
 	@echo "  qa               Run lint, fmt-check, type, and test."
 	@echo "  run-example      Execute the live llama.cpp strategy-comparison study example."
+	@echo "  live-smoke       Exercise both live tutorial runtimes with smoke-sized work."
+	@echo "  live-smoke-ollama Exercise the Ollama propose/critic tutorial."
+	@echo "  live-smoke-llama-cpp Exercise the managed llama.cpp tutorial with two replicates."
 	@echo "  examples-test    Execute all offline example scripts and notebooks."
 	@echo "  examples-coverage Require every public API export to appear in an example."
 	@echo "  examples-metrics Generate example and public-API badge artifacts."
@@ -66,6 +71,14 @@ docstrings-check: check-python
 
 run-example: check-python
 	PYTHONPATH=src $(PYTHON) examples/prompt_framing_study.py
+
+live-smoke-ollama: check-python
+	$(PYTHON) scripts/run_notebooks.py examples/tutorials/agents_propose_critic.ipynb
+
+live-smoke-llama-cpp: check-python
+	PROMPT_STUDY_REPLICATES=$(LIVE_SMOKE_REPLICATES) PYTHONPATH=src $(PYTHON) examples/prompt_framing_study.py
+
+live-smoke: live-smoke-ollama live-smoke-llama-cpp
 
 examples-test: check-python
 	$(PYTHON) scripts/run_examples.py

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -148,7 +148,7 @@ button.copybtn:hover {
 }
 
 .drc-notebook-download {
-  margin: 2rem 0 0;
+  margin: 0 0 1.5rem;
 }
 
 .drc-notebook-download a {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,11 +38,11 @@ autosummary_imported_members = True
 nitpicky = True
 nbsphinx_execute = "never"
 nbsphinx_allow_errors = False
-nbsphinx_epilog = r"""
+nbsphinx_prolog = r"""
 .. raw:: html
 
    <p class="drc-notebook-download">
-     <a href="{{ env.docname.split('/')[-1] }}.ipynb" download>Download notebook (.ipynb)</a>
+     <a href="{{ env.docname.split('/')[-1] }}.ipynb" download>Download this notebook (.ipynb)</a>
    </p>
 """
 intersphinx_mapping = {

--- a/docs/prompt_framing_study.rst
+++ b/docs/prompt_framing_study.rst
@@ -60,13 +60,18 @@ Optionally point the walkthrough at a specific local GGUF file:
    export LLAMA_CPP_MODEL=/path/to/model.gguf
    make run-example
 
-The default configuration uses eight replicates per condition. To push to a
-larger sample size, raise the replicate count explicitly:
+The default configuration uses 50 replicates per condition. To choose a
+different sample size, set the replicate count explicitly:
 
 .. code-block:: bash
 
    export PROMPT_STUDY_REPLICATES=12
    make run-example
+
+Maintainers can use ``make live-smoke-llama-cpp`` for a smoke-sized semantic
+check with two replicates per condition. The smoke target still exercises both
+model-backed prompt strategies; it does not replace the full walkthrough when
+you need study-scale results.
 
 The example writes canonical exports to
 ``artifacts/examples/prompt_strategy_comparison_study`` and writes a markdown
@@ -80,7 +85,9 @@ for the live-agent conditions: it expects a real ``llama.cpp`` runtime.
 If ``LLAMA_CPP_MODEL`` is not set, the client falls back to its built-in model
 defaults and Hugging Face repo settings. The first run may therefore download a
 model before the walkthrough executes, which is why the setup above includes
-``huggingface-hub``.
+``huggingface-hub``. The managed client allows up to five minutes for that first
+startup. On an unusually slow connection, set
+``LLAMA_CPP_STARTUP_TIMEOUT_SECONDS`` to a larger number of seconds.
 
 The script is intentionally written in a linear, step-by-step style so it can
 double as training material and as the literal-included documentation example.

--- a/docs/tutorials/factorial_analysis.rst
+++ b/docs/tutorials/factorial_analysis.rst
@@ -37,8 +37,11 @@ also defines the explicit condition matrix and deterministic participant.
    :start-at: def main()
    :end-before: def _study(
 
-Expected Output
+Selected Output
 ---------------
+
+The script also lists the fitted task-family terms and artifact directory.
+These lines capture the main regression checks:
 
 .. code-block:: text
 

--- a/docs/tutorials/full_stack_study.rst
+++ b/docs/tutorials/full_stack_study.rst
@@ -37,8 +37,11 @@ versioned event artifact.
    :language: python
    :linenos:
 
-Expected Output
+Selected Output
 ---------------
+
+The script also prints the selected problem and agent, mean outcome, and output
+directory. These lines capture the main completion checks:
 
 .. code-block:: text
 

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -77,6 +77,7 @@ its committed source.
 
 .. toctree::
    :maxdepth: 1
+   :hidden:
 
    problems_text_map
    problems_truss_grammar

--- a/docs/tutorials/process_comparison.rst
+++ b/docs/tutorials/process_comparison.rst
@@ -38,8 +38,12 @@ analysis path.
    :start-at: def main()
    :end-before: def _agent_run(
 
-Expected Output
+Selected Output
 ---------------
+
+The complete output also names the problem, reports each condition's mean
+outcome and transition-matrix p-value, and gives the artifact directory. These
+lines capture the main process-comparison checks:
 
 .. code-block:: text
 

--- a/docs/vscode_start.rst
+++ b/docs/vscode_start.rst
@@ -14,8 +14,53 @@ Requirements
 
 - Python 3.12 or newer. Maintainer workflows target the version in
   ``.python-version``.
-- VS Code with the Python extension.
+- VS Code with Microsoft's `Python extension
+  <https://marketplace.visualstudio.com/items?itemName=ms-python.python>`_ and
+  `Jupyter extension
+  <https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter>`_.
 - A VS Code integrated terminal.
+
+Run A Downloaded Tutorial Notebook
+----------------------------------
+
+Use these steps for any notebook in the :doc:`tutorial series
+<tutorials/index>`:
+
+1. Create an empty folder, open it with ``File > Open Folder`` in VS Code, and
+   open ``Terminal > New Terminal``.
+2. Create a virtual environment and install the notebook kernel support.
+
+   On macOS or Linux:
+
+   .. code-block:: bash
+
+      python -m venv .venv
+      source .venv/bin/activate
+      python -m pip install --upgrade pip ipykernel
+
+   On Windows PowerShell:
+
+   .. code-block:: powershell
+
+      py -3 -m venv .venv
+      .\.venv\Scripts\Activate.ps1
+      python -m pip install --upgrade pip ipykernel
+
+3. On the tutorial page, choose **Download this notebook (.ipynb)** near the
+   heading and save the file in the folder you opened in VS Code.
+4. Open the downloaded ``.ipynb`` file. Read its **Setup** section, then run
+   the listed ``python -m pip install ...`` command in the integrated terminal.
+   Each tutorial names its own package and any plotting dependencies.
+5. Use the kernel picker at the top right of the notebook, choose **Python
+   Environments**, and select the interpreter inside ``.venv``. If it is not
+   listed, run ``Python: Select Interpreter`` from the command palette and
+   select ``.venv/bin/python`` on macOS/Linux or
+   ``.venv\Scripts\python.exe`` on Windows.
+6. Scan the notebook's saved results, then choose **Run All** in the notebook
+   toolbar and compare them with the fresh output from your environment.
+
+The Ollama-backed propose/critic notebook has one additional requirement: keep
+``ollama serve`` running as instructed in that notebook's **Setup** section.
 
 Installed Package From PyPI
 ---------------------------
@@ -36,7 +81,7 @@ On Windows PowerShell:
 
 .. code-block:: powershell
 
-   py -3.12 -m venv .venv
+   py -3 -m venv .venv
    .\.venv\Scripts\Activate.ps1
    python -m pip install --upgrade pip
    python -m pip install design-research
@@ -130,7 +175,10 @@ Troubleshooting
 ---------------
 
 - If VS Code imports fail but the terminal works, reselect the ``.venv``
-  interpreter and reload the window.
+  interpreter or notebook kernel, then reload the window.
+- If a notebook says that no kernel is available, confirm that ``ipykernel`` is
+  installed in ``.venv`` and select that environment again with the kernel
+  picker.
 - If ``make`` uses the wrong Python, activate ``.venv`` in the terminal or run
   ``PYTHON=.venv/bin/python make test``.
 - If Windows activation is blocked, switch the terminal profile to Command

--- a/examples/README.md
+++ b/examples/README.md
@@ -40,6 +40,7 @@ Run locally with:
 ```bash
 make run-example
 make examples-test
+make live-smoke
 ```
 
 `make run-example` executes the live canonical walkthrough in
@@ -47,7 +48,19 @@ make examples-test
 If you want the default model download path, also install `huggingface-hub`;
 otherwise set `LLAMA_CPP_MODEL` to a specific local GGUF file. The live study
 defaults to 50 replicates per condition; set `PROMPT_STUDY_REPLICATES` to
-run a larger sample.
+choose a different sample size.
+
+`make live-smoke` is the maintainer gate for both model-backed tutorials. It
+executes the Ollama notebook once and runs the managed llama.cpp walkthrough
+with two replicates per condition (six total runs, four live model calls). Use
+`make live-smoke-ollama` or `make live-smoke-llama-cpp` when only one runtime is
+available. The Ollama target expects a running local service with `qwen3:8b`;
+the llama.cpp target expects `llama-cpp-python[server]` and either
+`huggingface-hub` or a local `LLAMA_CPP_MODEL` GGUF file. These targets are for
+periodic and pre-release checks on model-capable infrastructure; default CI
+remains deterministic and offline. A first-time managed startup may download
+the default model and waits up to five minutes; override that window with
+`LLAMA_CPP_STARTUP_TIMEOUT_SECONDS` when needed.
 
 `make examples-test` stays deterministic and offline-first by default. It runs
 all offline examples. Set `RUN_OLLAMA_EXAMPLES=1` for the propose/critic

--- a/examples/prompt_framing_study.py
+++ b/examples/prompt_framing_study.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import os
+from collections.abc import Sequence
 from pathlib import Path
 
 import design_research as dr
@@ -22,6 +23,9 @@ EXACT_PERMUTATION_THRESHOLD = 250_000
 MONTE_CARLO_PERMUTATIONS = 20_000
 PERMUTATION_TEST_SEED = 17
 STRATEGY_ORDER = (BASELINE_AGENT_ID, "neutral_prompt", "profit_focus_prompt")
+MODEL_BACKED_STRATEGY_IDS = ("neutral_prompt", "profit_focus_prompt")
+PRIMARY_METRIC = "predicted_share"
+SECONDARY_METRIC = "expected_demand_units"
 PAIRWISE_COMPARISONS = (
     ("profit_focus_prompt", "neutral_prompt"),
     ("neutral_prompt", BASELINE_AGENT_ID),
@@ -54,6 +58,8 @@ def main() -> None:
         host=str(runtime["host"]),
         port=int(runtime["port"]),
         context_window=int(runtime["context_window"]),
+        startup_timeout_seconds=float(runtime["startup_timeout_seconds"]),
+        request_timeout_seconds=float(runtime["request_timeout_seconds"]),
     ) as llm_client:
         # Each `agent_id` in the strategy bundle maps either to a public agent
         # id resolved directly by experiments or to one explicit binding that
@@ -92,6 +98,10 @@ def main() -> None:
             show_progress=False,
         )
 
+    # Treat this as a live-runtime check, not merely a deterministic-baseline
+    # check: every model-backed prompt strategy must produce usable evidence.
+    successful_results = _require_successful_model_strategies(results)
+
     # Export the standard analysis tables so the next steps can work from the
     # same artifacts users would inspect after their own runs.
     artifact_paths = dr.experiments.export_analysis_tables(
@@ -109,12 +119,12 @@ def main() -> None:
     # and another for a secondary business-facing metric, without hand-loading CSVs.
     primary_metric_rows = dr.analysis.build_condition_metric_table_from_artifacts(
         artifact_paths["events.csv"],
-        metric="market_share_proxy",
+        metric=PRIMARY_METRIC,
         condition_column="agent_id",
     )
     demand_metric_rows = dr.analysis.build_condition_metric_table_from_artifacts(
         artifact_paths["events.csv"],
-        metric="expected_demand_units",
+        metric=SECONDARY_METRIC,
         condition_column="agent_id",
     )
 
@@ -122,7 +132,7 @@ def main() -> None:
     # permutation test helper.
     comparison_report = dr.analysis.compare_condition_pairs_from_artifacts(
         artifact_paths["events.csv"],
-        metric="market_share_proxy",
+        metric=PRIMARY_METRIC,
         condition_column="agent_id",
         condition_pairs=PAIRWISE_COMPARISONS,
         alternative="greater",
@@ -156,11 +166,8 @@ def main() -> None:
     # summary after the run finishes.
     primary_means = condition_means(primary_metric_rows)
     demand_means = condition_means(demand_metric_rows)
-    successful_results = [result for result in results if result.status.value == "success"]
 
-    # Fail loudly if the live walkthrough did not actually produce usable data.
-    if not successful_results:
-        raise RuntimeError("The live walkthrough completed without any successful runs.")
+    # Fail loudly if the exported live data is not structurally usable.
     if validation_report.errors:
         raise RuntimeError(
             "Unified event table validation failed:\n- " + "\n- ".join(validation_report.errors)
@@ -180,8 +187,8 @@ def main() -> None:
     for strategy_name in STRATEGY_ORDER:
         print(
             f"  - agent_id={strategy_name}: "
-            f"mean_market_share_proxy={primary_means.get(strategy_name, 0.0):.4f}, "
-            f"mean_expected_demand_units={demand_means.get(strategy_name, 0.0):.0f}"
+            f"mean_{PRIMARY_METRIC}={primary_means.get(strategy_name, 0.0):.4f}, "
+            f"mean_{SECONDARY_METRIC}={demand_means.get(strategy_name, 0.0):.0f}"
         )
     print(comparison_report.render_brief())
     print(dr.experiments.render_significance_brief(significance_rows))
@@ -250,6 +257,50 @@ def condition_means(rows: list[dict[str, object]]) -> dict[str, float]:
     }
 
 
+def _require_successful_model_strategies(results: Sequence[object]) -> list[object]:
+    """Require observed successes from every model-backed prompt strategy."""
+    successful_results: list[object] = []
+    successful_strategy_ids: set[str] = set()
+    model_attempts: dict[str, list[str]] = {
+        strategy_id: [] for strategy_id in MODEL_BACKED_STRATEGY_IDS
+    }
+    for result in results:
+        raw_status = getattr(result, "status", None)
+        status = getattr(raw_status, "value", raw_status)
+        run_spec = getattr(result, "run_spec", None)
+        strategy_ref = getattr(run_spec, "agent_spec_ref", None)
+        strategy_id = str(strategy_ref) if strategy_ref is not None else None
+        if strategy_id in model_attempts:
+            error_info = getattr(result, "error_info", None)
+            detail = str(error_info).strip() if error_info else str(status)
+            if detail not in model_attempts[strategy_id]:
+                model_attempts[strategy_id].append(detail)
+        if status != "success":
+            continue
+        successful_results.append(result)
+        if strategy_id is not None:
+            successful_strategy_ids.add(strategy_id)
+
+    missing_strategy_ids = [
+        strategy_id
+        for strategy_id in MODEL_BACKED_STRATEGY_IDS
+        if strategy_id not in successful_strategy_ids
+    ]
+    if missing_strategy_ids:
+        attempt_summary = "; ".join(
+            f"{strategy_id}: {', '.join(model_attempts[strategy_id]) or 'no result'}"
+            for strategy_id in missing_strategy_ids
+        )
+        raise RuntimeError(
+            "The live walkthrough requires at least one successful result from each "
+            "model-backed prompt strategy. Missing successful strategies: "
+            + ", ".join(missing_strategy_ids)
+            + ". Observed attempts: "
+            + attempt_summary
+        )
+    return successful_results
+
+
 def decision_candidate_schema(problem: object) -> dict[str, object]:
     """Build a JSON schema for discrete decision-factor candidates."""
     properties: dict[str, object] = {}
@@ -316,6 +367,10 @@ def llama_cpp_runtime_config(*, default_replicates: int) -> dict[str, object]:
         "host": os.getenv("LLAMA_CPP_HOST", "127.0.0.1").strip() or "127.0.0.1",
         "port": int(os.getenv("LLAMA_CPP_PORT", "8001")),
         "context_window": int(os.getenv("LLAMA_CPP_CONTEXT_WINDOW", "4096")),
+        # The first startup may include a roughly 1 GB model download. Keep the
+        # wait finite but long enough for an ordinary laptop connection.
+        "startup_timeout_seconds": float(os.getenv("LLAMA_CPP_STARTUP_TIMEOUT_SECONDS", "300")),
+        "request_timeout_seconds": float(os.getenv("LLAMA_CPP_REQUEST_TIMEOUT_SECONDS", "120")),
         "replicates": replicates,
     }
 

--- a/examples/tutorials/agents_propose_critic.ipynb
+++ b/examples/tutorials/agents_propose_critic.ipynb
@@ -14,14 +14,23 @@
     "\n",
     "## Setup\n",
     "\n",
-    "```bash\n",
-    "python -m pip install design-research-agents==0.6.0\n",
-    "ollama pull qwen3:8b\n",
-    "ollama serve\n",
-    "```\n",
+    "1. [Install Ollama](https://ollama.com/download). Start the Ollama app, or keep the\n",
+    "   server running in Terminal A:\n",
     "\n",
-    "Leave `ollama serve` running, open the notebook in VS Code, and select the environment\n",
-    "where `design-research-agents` is installed. Model wording can vary; the stored output\n",
+    "   ```bash\n",
+    "   ollama serve\n",
+    "   ```\n",
+    "\n",
+    "2. In Terminal B, install the package, fetch the tutorial model, and verify it is listed:\n",
+    "\n",
+    "   ```bash\n",
+    "   python -m pip install design-research-agents==0.6.0\n",
+    "   ollama pull qwen3:8b\n",
+    "   ollama list\n",
+    "   ```\n",
+    "\n",
+    "Open the notebook in VS Code, select that Python environment, confirm `qwen3:8b` appears\n",
+    "in `ollama list`, and then choose **Run All**. Model wording can vary; the stored output\n",
     "below is one captured run."
    ]
   },
@@ -135,9 +144,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "- Modular connectors simplify maintenance by enabling quick replacement of individual components without system disassembly.  \n",
-      "- Modular connectors enhance reliability by isolating component failures and facilitating targeted diagnostics.  \n",
-      "- Modular connectors introduce potential complexity in integration and may increase manufacturing costs compared to monolithic designs.\n",
+      "- Modular connectors simplify maintenance by enabling quick replacement of individual components without full system disassembly.  \n",
+      "- Modular connectors enhance reliability by isolating component failures and allowing targeted repairs without system-wide disruptions.  \n",
+      "- Modular connectors may introduce compatibility complexities and increased part inventory management requirements compared to monolithic designs.\n",
       "Approved: True\n",
       "Iterations: 1\n"
      ]
@@ -179,7 +188,12 @@
     "    print(f\"Iteration {iteration['iteration']}\")\n",
     "    print(\"Approved:\", iteration[\"approved\"])\n",
     "    print(\"Feedback:\", iteration[\"feedback\"] or \"(none)\")\n",
-    "    print(\"Revision goals:\", iteration[\"revision_goals\"])"
+    "    print(\"Revision goals:\", iteration[\"revision_goals\"])\n",
+    "\n",
+    "if not result.success or not result.approved:\n",
+    "    raise RuntimeError(\n",
+    "        \"The live propose/critic workflow did not finish with a successful, approved result.\"\n",
+    "    )"
    ]
   },
   {
@@ -197,9 +211,9 @@
  ],
  "metadata": {
   "design_research_freshness": {
-   "output_sha256": "1e5de8b3d730380000edb0d8e871f68a1527a0d74ccfe996f740e920bcff18d7",
+   "output_sha256": "f0d50abd63ba28ac1ef77f74add36a335e10db691ffecb53038f102b77a0c2dc",
    "schema_version": 1,
-   "source_sha256": "ed0628769096a227fc15fdd4f4b9f7817e251048596edb115e6c7e3f5c135849"
+   "source_sha256": "a21346a02e2ef4afe979422fe6f1ec03cbad97c60299eeb96222c2b458b00906"
   },
   "kernelspec": {
    "display_name": "Python 3",
@@ -216,7 +230,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.12.13"
   },
   "nbsphinx": {
    "execute": "never"

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -16,8 +16,14 @@ VERSION_PATH = Path("src/design_research/_version.py")
 COMPATIBILITY_PATH = DOCS_DIR / "compatibility.rst"
 WORKSHOP_SETUP_PATH = DOCS_DIR / "workshop-setup.rst"
 IDETC_REQUIREMENTS_PATH = Path("tutorial_materials/idetc2026/requirements.txt")
+PROMPT_STUDY_PATH = Path("examples/prompt_framing_study.py")
+PROMPT_STUDY_DOC_PATH = DOCS_DIR / "prompt_framing_study.rst"
 INSTALL_REQUIREMENT_PATTERN = re.compile(
     r"design-research(?:-(?:problems|agents|experiments|analysis))?==(?P<version>[0-9.]+)"
+)
+DEFAULT_REPLICATES_PATTERN = re.compile(
+    r"default configuration uses (?P<count>[0-9]+) replicates per condition",
+    flags=re.IGNORECASE,
 )
 
 
@@ -74,6 +80,7 @@ def validate_docs_tree() -> list[str]:
     elif "design_research" not in API_PATH.read_text(encoding="utf-8"):
         errors.append("docs/api.rst does not reference the package module.")
     errors.extend(validate_documented_versions())
+    errors.extend(validate_prompt_study_replicates())
     return errors
 
 
@@ -128,6 +135,38 @@ def validate_documented_versions() -> list[str]:
         if f"``{version}``" not in compatibility:
             errors.append(f"docs/compatibility.rst omits {package_name} version {version}.")
     return errors
+
+
+def prompt_study_default_replicates() -> int:
+    """Read the walkthrough's default replicate count from its source file."""
+    module = ast.parse(PROMPT_STUDY_PATH.read_text(encoding="utf-8"))
+    for node in module.body:
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Constant):
+            continue
+        if not isinstance(node.value.value, int):
+            continue
+        if any(
+            isinstance(target, ast.Name) and target.id == "DEFAULT_REPLICATES_PER_CONDITION"
+            for target in node.targets
+        ):
+            return node.value.value
+    raise ValueError(f"{PROMPT_STUDY_PATH} omits integer DEFAULT_REPLICATES_PER_CONDITION.")
+
+
+def validate_prompt_study_replicates() -> list[str]:
+    """Keep the documented walkthrough default synchronized with the script."""
+    documented = DEFAULT_REPLICATES_PATTERN.search(
+        PROMPT_STUDY_DOC_PATH.read_text(encoding="utf-8")
+    )
+    if documented is None:
+        return [f"{PROMPT_STUDY_DOC_PATH} omits the default prompt-study replicate count."]
+    expected = prompt_study_default_replicates()
+    observed = int(documented.group("count"))
+    if observed != expected:
+        return [
+            f"{PROMPT_STUDY_DOC_PATH} documents {observed} default replicates; expected {expected}."
+        ]
+    return []
 
 
 def main() -> int:

--- a/tests/test_example_tooling.py
+++ b/tests/test_example_tooling.py
@@ -226,3 +226,32 @@ def test_notebook_freshness_detects_source_and_output_drift(
     assert freshness.validate_notebook(notebook) == [
         "saved outputs changed after freshness metadata was recorded"
     ]
+
+
+def test_docs_consistency_tracks_prompt_study_default(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    """Walkthrough prose should not drift from its executable default."""
+    checker = _load_script_module(monkeypatch, "check_docs_consistency")
+    study_path = tmp_path / "prompt_study.py"
+    docs_path = tmp_path / "prompt_study.rst"
+    study_path.write_text(
+        "DEFAULT_REPLICATES_PER_CONDITION = 50\n",
+        encoding="utf-8",
+    )
+    docs_path.write_text(
+        "The default configuration uses 50 replicates per condition.\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(checker, "PROMPT_STUDY_PATH", study_path)
+    monkeypatch.setattr(checker, "PROMPT_STUDY_DOC_PATH", docs_path)
+
+    assert checker.validate_prompt_study_replicates() == []
+
+    docs_path.write_text(
+        "The default configuration uses 8 replicates per condition.\n",
+        encoding="utf-8",
+    )
+    assert checker.validate_prompt_study_replicates() == [
+        f"{docs_path} documents 8 default replicates; expected 50."
+    ]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import runpy
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -59,6 +61,14 @@ def _notebook_has_png(notebook_name: str) -> bool:
         "image/png" in output.get("data", {})
         for cell in notebook["cells"]
         for output in cell.get("outputs", [])
+    )
+
+
+def _prompt_study_result(strategy_id: str, *, status: str) -> SimpleNamespace:
+    """Build the minimal run-result shape consumed by the live semantic guard."""
+    return SimpleNamespace(
+        status=SimpleNamespace(value=status),
+        run_spec=SimpleNamespace(agent_spec_ref=strategy_id),
     )
 
 
@@ -172,6 +182,17 @@ def test_agents_propose_critic_tutorial_records_llm_result() -> None:
     assert "tradeoff" in output
 
 
+def test_agents_propose_critic_tutorial_enforces_successful_approval() -> None:
+    """The Ollama tutorial should fail when its final result is not usable."""
+    notebook = _load_notebook("agents_propose_critic.ipynb")
+    source = "\n".join(
+        "".join(cell.get("source", [])) for cell in notebook["cells"] if cell["cell_type"] == "code"
+    )
+
+    assert "if not result.success or not result.approved:" in source
+    assert "raise RuntimeError(" in source
+
+
 def test_agents_workflow_tutorial_records_deterministic_result() -> None:
     """The advanced Agents tutorial should retain its dependency-graph result."""
     output = _notebook_output_text("agents_workflow.ipynb")
@@ -209,6 +230,74 @@ def test_prompt_framing_walkthrough_uses_public_prompt_workflow_agent() -> None:
     assert "build_json_prompt_workflow" in source
     assert "PromptWorkflowAgent" in source
     assert "agent_bindings" in source
+
+
+def test_prompt_framing_walkthrough_rejects_baseline_only_success() -> None:
+    """A deterministic baseline must not masquerade as a passing live smoke test."""
+    namespace = runpy.run_path(str(EXAMPLES_DIR / "prompt_framing_study.py"))
+    require_successes = namespace["_require_successful_model_strategies"]
+    results = [
+        _prompt_study_result("SeededRandomBaselineAgent", status="success"),
+        _prompt_study_result("neutral_prompt", status="failed"),
+        _prompt_study_result("profit_focus_prompt", status="failed"),
+    ]
+
+    with pytest.raises(
+        RuntimeError,
+        match="Missing successful strategies: neutral_prompt, profit_focus_prompt",
+    ):
+        require_successes(results)
+
+
+def test_prompt_framing_walkthrough_requires_each_model_strategy() -> None:
+    """Every model-backed strategy should contribute an observed successful result."""
+    namespace = runpy.run_path(str(EXAMPLES_DIR / "prompt_framing_study.py"))
+    require_successes = namespace["_require_successful_model_strategies"]
+    results = [
+        _prompt_study_result("SeededRandomBaselineAgent", status="success"),
+        _prompt_study_result("neutral_prompt", status="success"),
+        _prompt_study_result("profit_focus_prompt", status="failed"),
+    ]
+
+    with pytest.raises(
+        RuntimeError,
+        match="Missing successful strategies: profit_focus_prompt",
+    ):
+        require_successes(results)
+
+
+def test_prompt_framing_walkthrough_accepts_both_model_strategies() -> None:
+    """The guard should pass after both live prompt strategies succeed."""
+    namespace = runpy.run_path(str(EXAMPLES_DIR / "prompt_framing_study.py"))
+    require_successes = namespace["_require_successful_model_strategies"]
+    results = [
+        _prompt_study_result("SeededRandomBaselineAgent", status="failed"),
+        _prompt_study_result("neutral_prompt", status="success"),
+        _prompt_study_result("profit_focus_prompt", status="success"),
+    ]
+
+    assert require_successes(results) == results[1:]
+
+
+def test_prompt_framing_metrics_match_pinned_problem_integration() -> None:
+    """Analysis metric names should match the evaluator's exported rows."""
+    from design_research_problems.integration import (
+        evaluate_problem_output,
+        resolve_problem_binding,
+    )
+
+    namespace = runpy.run_path(str(EXAMPLES_DIR / "prompt_framing_study.py"))
+    binding = resolve_problem_binding(namespace["PROBLEM_ID"])
+    problem = binding.problem_object
+    candidate = {factor.key: factor.levels[0] for factor in problem.option_factors}
+    rows = evaluate_problem_output(
+        binding,
+        candidate,
+    )
+    metric_names = {row["metric_name"] for row in rows}
+
+    assert namespace["PRIMARY_METRIC"] in metric_names
+    assert namespace["SECONDARY_METRIC"] in metric_names
 
 
 def test_examples_stay_on_public_artifact_helpers() -> None:


### PR DESCRIPTION
## Summary

- complete the VS Code and Jupyter first-run path and move notebook downloads to the top of rendered tutorials
- make live Ollama and llama.cpp examples fail unless their model-backed work succeeds
- add focused live-smoke Make targets while keeping default CI offline
- correct walkthrough replicate and exported-metric drift, with regression checks
- clarify selected-output excerpts and remove duplicate visible tutorial navigation

## Validation

- make ci PYTHON=.venv/bin/python
- make docs PYTHON=.venv/bin/python
- make live-smoke-ollama PYTHON=.venv/bin/python
- make live-smoke-llama-cpp PYTHON=.venv/bin/python
- desktop and mobile Playwright review of the rendered beginner path

## Infrastructure note

The repository has no model-capable Actions runner, so periodic live execution remains an external or pre-release automation concern. The focused commands added here are ready for that runner.