### PR TITLE
Use system trust for workshop downloads

### DIFF
--- a/.github/workflows/workshop-preflight.yml
+++ b/.github/workflows/workshop-preflight.yml
@@ -37,5 +37,30 @@ jobs:
       - name: Verify published setup files
         run: python scripts/build_idetc2026_bundle.py --check --kind setup
 
-      - name: Run clean participant install and preflight
-        run: python scripts/run_idetc2026_preflight_install.py
+      - name: Run participant setup with native downloader on macOS or Linux
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          cd "$RUNNER_TEMP"
+          mkdir -p design-research-workshop
+          cd design-research-workshop
+          curl -fsSLo requirements.txt 'https://cmudrc.github.io/design-research/_static/workshop-requirements.txt'
+          curl -fsSLo preflight.py 'https://cmudrc.github.io/design-research/_static/workshop-preflight.py'
+          python3.12 -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install -r requirements.txt
+          .venv/bin/python preflight.py
+
+      - name: Run participant setup with native downloader on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Set-Location $env:RUNNER_TEMP
+          New-Item -ItemType Directory -Force design-research-workshop | Out-Null
+          Set-Location design-research-workshop
+          curl.exe -fsSLo requirements.txt 'https://cmudrc.github.io/design-research/_static/workshop-requirements.txt'
+          curl.exe -fsSLo preflight.py 'https://cmudrc.github.io/design-research/_static/workshop-preflight.py'
+          python -m venv .venv
+          .\.venv\Scripts\python.exe -m pip install --upgrade pip
+          .\.venv\Scripts\python.exe -m pip install -r requirements.txt
+          .\.venv\Scripts\python.exe preflight.py

--- a/docs/workshop-setup.rst
+++ b/docs/workshop-setup.rst
@@ -15,7 +15,8 @@ On macOS or Linux:
 
    mkdir -p design-research-workshop
    cd design-research-workshop
-   python3.12 -c "from urllib.request import urlretrieve as get; get('https://cmudrc.github.io/design-research/_static/workshop-requirements.txt', 'requirements.txt'); get('https://cmudrc.github.io/design-research/_static/workshop-preflight.py', 'preflight.py')"
+   curl -fsSLo requirements.txt 'https://cmudrc.github.io/design-research/_static/workshop-requirements.txt'
+   curl -fsSLo preflight.py 'https://cmudrc.github.io/design-research/_static/workshop-preflight.py'
    python3.12 -m venv .venv
    .venv/bin/python -m pip install --upgrade pip
    .venv/bin/python -m pip install -r requirements.txt
@@ -27,11 +28,12 @@ On Windows PowerShell:
 
    New-Item -ItemType Directory -Force design-research-workshop | Out-Null
    Set-Location design-research-workshop
-   py -3.12 -c "from urllib.request import urlretrieve as get; get('https://cmudrc.github.io/design-research/_static/workshop-requirements.txt', 'requirements.txt'); get('https://cmudrc.github.io/design-research/_static/workshop-preflight.py', 'preflight.py')"
+   curl.exe -fsSLo requirements.txt 'https://cmudrc.github.io/design-research/_static/workshop-requirements.txt'
+   curl.exe -fsSLo preflight.py 'https://cmudrc.github.io/design-research/_static/workshop-preflight.py'
    py -3.12 -m venv .venv
-   .venv\Scripts\python -m pip install --upgrade pip
-   .venv\Scripts\python -m pip install -r requirements.txt
-   .venv\Scripts\python preflight.py
+   .\.venv\Scripts\python.exe -m pip install --upgrade pip
+   .\.venv\Scripts\python.exe -m pip install -r requirements.txt
+   .\.venv\Scripts\python.exe preflight.py
 
 A successful check ends with ``Preflight passed. You are ready for the
 workshop.`` Keep the ``design-research-workshop`` folder. Activity materials

--- a/tests/test_idetc2026_bundle.py
+++ b/tests/test_idetc2026_bundle.py
@@ -81,6 +81,13 @@ def test_setup_assets_are_direct_environment_only_downloads() -> None:
     assert "idetc2026-design-research-setup.zip" not in setup_page
     assert "workshop-requirements.txt" in setup_page
     assert "workshop-preflight.py" in setup_page
+    assert "curl -fsSLo requirements.txt" in setup_page
+    assert "curl -fsSLo preflight.py" in setup_page
+    assert "curl.exe -fsSLo requirements.txt" in setup_page
+    assert "curl.exe -fsSLo preflight.py" in setup_page
+    assert "urllib.request" not in setup_page
+    assert "--insecure" not in setup_page
+    assert "curl -k" not in setup_page
     assert "IDETC" not in setup_page
     assert "ASME" not in setup_page
 


### PR DESCRIPTION
## Summary
- replace Python urllib downloads with curl/curl.exe so the setup uses OS certificate trust
- correct the Windows virtual-environment executable paths
- run the native download path directly in the Ubuntu, macOS, and Windows preflight matrix
- guard the published instructions against urllib and insecure curl flags

## Validation
- full clean install and preflight: Mali (macOS arm64)
- full clean install and preflight: Oliver (macOS arm64)
- full clean install and preflight: Basho (Windows x86-64)
- targeted bundle/setup tests
- warning-as-error Sphinx docs build
- workflow syntax lint
